### PR TITLE
Fix the build failure for a newly initialized project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 out
 reports
 .DS_Store
+.idea

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# Default config properties, can be overridden by ~/.gradle/gradle.properties
+sonatypeUsername=
+sonatypePassword=


### PR DESCRIPTION
Add the default gradle.properties, which can be overridden by the one from home directory.
