### PR TITLE
Set $MODULE_DIR$ as Junit run/debug defaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,13 @@ allprojects {
     apply plugin: 'signing'
 }
 
+project(':') {
+    idea.workspace.iws.withXml { provider ->
+        def junitDefaults = provider.node.component.find { it.@name == 'RunManager' }.configuration.find { it.@type == 'JUnit' }
+        junitDefaults.option.find { it.@name == 'WORKING_DIRECTORY' }.@value = '$MODULE_DIR$'
+    }
+}
+
 subprojects {
     apply plugin: 'java'
     group = 'com.github.dreamhead'


### PR DESCRIPTION
... the file path within the sub projects can be unified

The tricky thing is idea.workspace.iws can only be configured on root project, otherwise you simply get a unclear null object called on withXml error.
