### PR TITLE
Ensure default content type does not override existing one

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractContentResponseHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractContentResponseHandler.java
@@ -14,7 +14,18 @@ public abstract class AbstractContentResponseHandler implements ResponseHandler 
         ChannelBuffer buffer = ChannelBuffers.dynamicBuffer();
         writeContentResponse(request, buffer);
         response.setContent(buffer);
-        response.setHeader("Content-Type", "text/html; charset=UTF-8");
+        if (!hasContentType(response)) {
+            response.setHeader("Content-Type", "text/html; charset=UTF-8");
+        }
         response.setHeader("Content-Length", response.getContent().writerIndex());
+    }
+
+    private boolean hasContentType(HttpResponse response) {
+        for (String header : response.getHeaderNames()) {
+            if (header.equalsIgnoreCase("Content-Type")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoTest.java
@@ -1,5 +1,7 @@
 package com.github.dreamhead.moco;
 
+import com.github.dreamhead.moco.handler.ContentHandler;
+import org.apache.http.Header;
 import org.apache.http.HttpVersion;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.HttpResponseException;
@@ -405,6 +407,19 @@ public class MocoTest extends AbstractMocoTest {
                 assertThat(json, is("application/json"));
                 String bar = Request.Get(root()).execute().returnResponse().getHeaders("foo")[0].getValue();
                 assertThat(bar, is("bar"));
+            }
+        });
+    }
+
+    @Test
+    public void should_not_add_content_type_header_if_exists() throws Exception {
+        server.response(header("content-type", "application/xml"), new ContentHandler(text("foo")));
+        running(server, new Runnable() {
+            @Override
+            public void run() throws IOException {
+            Header[] headers = Request.Get(root()).execute().returnResponse().getHeaders("content-type");
+            assertThat(headers.length, is(1));
+            assertThat(headers[0].getValue(), is("application/xml"));
             }
         });
     }


### PR DESCRIPTION
See https://github.com/dreamhead/moco/issues/13

Despite this fix, users will still need to be careful when using a `ContentHandler` that response handlers adding a content type are used _before_ the `ContentHandler`. Otherwise, it is unable to see the header and will apply the default. 
