### PR TITLE
There is no need to use the absolute path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ java -jar moco-runner-<version>-standalone.jar start -p 12306 -c foo.json
 
 ## Documents
 * More [Usages](moco-doc/usage.md)
-* Detailed [APIs](moco-doc/apis.md?raw=true)
-* [Global Settings](moco-doc/global-settings.md?raw=true) for multiple configuration files.
+* Detailed [APIs](moco-doc/apis.md)
+* [Global Settings](moco-doc/global-settings.md) for multiple configuration files.
 
 ## Build
 Make sure you have JDK and Gradle installed.


### PR DESCRIPTION
If you want to display a image in README,just simply append "?raw=true" to the image url.
