### PR TITLE
add test for some handlers

### DIFF
--- a/moco-core/src/test/java/com/github/dreamhead/moco/handler/ProxyResponseHandlerTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/handler/ProxyResponseHandlerTest.java
@@ -1,0 +1,99 @@
+package com.github.dreamhead.moco.handler;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.github.dreamhead.moco.handler.failover.Failover;
+
+public class ProxyResponseHandlerTest {
+
+	private Method method;
+	private URL url;
+	private ProxyResponseHandler handler;
+	private HttpRequest request;
+
+	@Before
+	public void setUp() throws Exception {
+		url = new URL("http://github.io/moco/");
+		handler = new ProxyResponseHandler(url, Mockito.mock(Failover.class));
+	}
+
+	@Test
+	public void should_create_get_base_request() throws Exception {
+		assertThat(
+				createBaseRequest(url, HttpMethod.GET).getClass().toString(),
+				is(HttpGet.class.toString()));
+	}
+
+	@Test(expected = InvocationTargetException.class)
+	public void should_throw_exception_with_unknown_method() throws Exception {
+		createBaseRequest(url, HttpMethod.valueOf("UNKNOWN_METHOD"));
+	}
+
+	@Test
+	public void should_parse_http_1_0() throws Exception {
+		request = new DefaultFullHttpRequest(
+				io.netty.handler.codec.http.HttpVersion.HTTP_1_0,
+				HttpMethod.GET, url.toString());
+		HttpVersion version = createVersion(request);
+		assertThat(version.getMajor(), is(1));
+		assertThat(version.getMinor(), is(0));
+	}
+
+	@Test
+	public void should_parse_http_1_1() throws Exception {
+		request = new DefaultFullHttpRequest(
+				io.netty.handler.codec.http.HttpVersion.HTTP_1_1,
+				HttpMethod.GET, url.toString());
+		HttpVersion version = createVersion(request);
+		assertThat(version.getMajor(), is(1));
+		assertThat(version.getMinor(), is(1));
+	}
+
+	@Test
+	public void should_return_right_remote_url() throws Exception {
+		request = new DefaultFullHttpRequest(
+				io.netty.handler.codec.http.HttpVersion.HTTP_1_0,
+				HttpMethod.GET, url.toString());
+		URL url = remoteUrl(request);
+		assertThat(url.getHost(), is("github.io"));
+		assertThat(url.getProtocol(), is("http"));
+		assertThat(url.getPort(), is(-1));
+	}
+
+	private HttpRequestBase createBaseRequest(URL url, HttpMethod httpMethod)
+			throws Exception {
+		method = ProxyResponseHandler.class.getDeclaredMethod(
+				"createBaseRequest", URL.class, HttpMethod.class);
+		method.setAccessible(true);
+		return (HttpRequestBase) method.invoke(handler, url, httpMethod);
+	}
+
+	private HttpVersion createVersion(HttpRequest request) throws Exception {
+		method = ProxyResponseHandler.class.getDeclaredMethod("createVersion",
+				HttpRequest.class);
+		method.setAccessible(true);
+		return (HttpVersion) method.invoke(handler, request);
+	}
+
+	private URL remoteUrl(HttpRequest request) throws Exception {
+		method = ProxyResponseHandler.class.getDeclaredMethod("remoteUrl",
+				HttpRequest.class);
+		method.setAccessible(true);
+		return (URL) method.invoke(handler, request);
+	}
+}

--- a/moco-core/src/test/java/com/github/dreamhead/moco/handler/ResponseHandlersTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/handler/ResponseHandlersTest.java
@@ -1,0 +1,45 @@
+package com.github.dreamhead.moco.handler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.dreamhead.moco.resource.ContentResource;
+import com.github.dreamhead.moco.resource.Resource;
+
+public class ResponseHandlersTest {
+
+	private Resource resource;
+	private ContentResource contentResource;
+
+	@Before
+	public void setUp() throws Exception {
+		resource = mock(Resource.class);
+		contentResource = mock(ContentResource.class);
+	}
+
+	@Test
+	public void should_return_content_handle() {
+		when(contentResource.id()).thenReturn("text");
+		assertThat(ResponseHandlers.responseHandler(contentResource).getClass()
+				.toString(), is(ContentHandler.class.toString()));
+	}
+
+	@Test
+	public void should_return_version_handle() {
+		when(resource.id()).thenReturn("version");
+		assertThat(ResponseHandlers.responseHandler(resource).getClass()
+				.toString(), is(VersionResponseHandler.class.toString()));
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void should_throw_exception_when_no_handle() throws Exception {
+		when(resource.id()).thenReturn("UNKNOWN");
+		ResponseHandlers.responseHandler(resource);
+	}
+
+}

--- a/moco-core/src/test/java/com/github/dreamhead/moco/handler/StatusCodeResponseHandlerTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/handler/StatusCodeResponseHandlerTest.java
@@ -1,0 +1,51 @@
+package com.github.dreamhead.moco.handler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class StatusCodeResponseHandlerTest {
+
+	private FullHttpRequest request;
+	private FullHttpResponse response;
+	private StatusCodeResponseHandler handler;
+	private HttpResponseStatus status;
+
+	@Before
+	public void setUp() throws Exception {
+		request = mock(FullHttpRequest.class);
+		response = mock(FullHttpResponse.class);
+		doAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				status = (HttpResponseStatus) invocation.getArguments()[0];
+				return null;
+			}
+		}).when(response).setStatus(any(HttpResponseStatus.class));
+	}
+
+	@Test
+	public void should_return_not_found() {
+		handler = new StatusCodeResponseHandler(404);
+		handler.writeToResponse(request, response);
+		assertThat(status.reasonPhrase(), is("Not Found"));
+	}
+
+	@Test
+	public void should_return_unknown_status() {
+		handler = new StatusCodeResponseHandler(601);
+		handler.writeToResponse(request, response);
+		assertThat(status.reasonPhrase(), is("Unknown Status (601)"));
+	}
+
+}


### PR DESCRIPTION
Frankly, I'm a little confused about the code with Resource.class、ContentResource.class and ResponseHandlers.class.

The code works well but it looks very strange.

In ResponseHandlers.class we use Resource.class as a parameter,but actually we can use Resource only when we get a VersionResponseHandler.If we want to get ContentHandler we must use ContentResource instead of Resource.

You can see the code in ResponseHandlersTest.If I want to test all,I must prepare two class Resource and ContentResource not only one Resource.

And with the code in ContentHandler.class and VersionResponseHandler.class,they hold different resource.But in ResponseHandlers we use the same resource to construct them.

Is there something wrong with my understanding ? Or there is a better way to organize the code in test file ?

BTW:
Is there a speech about moco in OpenpartyChengdu this Sunday?
I'm looking forward to it~！(^o^)
