### PR TITLE
use proguard tool to reduce size of uberjar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,8 +209,19 @@ project(':moco-runner') {
             injar= jar.archivePath
             jar.classifier="proguard"
             outJar= jar.archivePath
+            javaBase=System.properties["java.home"];
+            javaRt="/lib/rt.jar"
+            if(System.properties["os.name"].toLowerCase().contains("mac"))
+            {
+                if(!new File(javaBase+javaRt).exists())
+                {
+                    javaRt="/../Classes/classes.jar"
+                }
+            }
         }
         injars injar
+        libraryjars javaBase+javaRt
+        println(javaBase+javaRt)
         outjars outJar
         configuration '../proguard.pro'
     }
@@ -221,7 +232,7 @@ project(':moco-runner') {
             outJar= jar.archivePath
         }
         testLogging { exceptionFormat "full" }
-        classpath = classpath-files(sourceSets.main.output.classesDir)-files(configurations.compile)+files(outJar)
+        classpath = classpath-files(sourceSets.main.output.classesDir)-files(configurations.runtime)+files(outJar)
     }
 
     artifacts {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 # Default config properties, can be overridden by ~/.gradle/gradle.properties
 sonatypeUsername=
 sonatypePassword=
+org.gradle.daemon=true
+org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8

--- a/proguard.pro
+++ b/proguard.pro
@@ -1,5 +1,3 @@
--libraryjars <java.home>/lib/rt.jar
--libraryjars <java.home>/lib/jce.jar
 -printusage shrinking.output
 
 -dontobfuscate
@@ -11,7 +9,19 @@
     public static void main(java.lang.String[]);
 }
 
--keep public class com.github.dreamhead.moco.** {*;}
+
+-keep public class com.github.dreamhead.moco.parser.model.*{*;}
+-keep public class com.github.dreamhead.moco.Moco{*;}
+-keep public class com.github.dreamhead.moco.handler.*{*;}
+-keep public class com.github.dreamhead.moco.runner.ShutdownRunner{
+    public int shutdownPort();
+}
+-keepclassmembers enum com.jayway.jsonpath.Option {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+
 -keep public class org.apache.http.**{*;}
 -keep public class com.google.common.io.Files{*;}
 -keep public class org.apache.commons.io.FilenameUtils{*;}
@@ -20,14 +30,17 @@
 -keep public class ch.** {*;}
 -keep public class org.apache.commons.logging.impl.**{*;}
 -keep public class com.fasterxml.jackson.databind.**{*;}
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
+
+#jce.jar
+-dontwarn org.apache.http.impl.auth.**
+#jsse.jar
+-dontwarn org.apache.http.conn.**
+-dontwarn org.apache.http.impl.**
 
 -dontwarn io.netty.**
--dontwarn com.jayway.jsonpath.**
--dontwarn ch.qos.logback.**
+-dontwarn com.jayway.jsonpath.spi.impl.JacksonProvider
+-dontwarn ch.qos.logback.core.**
+-dontwarn ch.qos.logback.classic.**
 -dontwarn freemarker.**
 -dontwarn org.slf4j.**
 -dontwarn org.apache.log4j.**


### PR DESCRIPTION
Add two tasks named with proguard and proguardCheck.Task proguard uses proguard tool to shrinking the uberjar.The size is reduced from 8M to 4.6M.

Of course here are more thing we can do to make a smaller jar and proguardCheck is a way to run test with the package jar.Be relax to change proguard.pro settings and use proguardCheck to check it works well or not.

Just as you say,gradle is more flexible and easy to do custom task(^_^)
