### PR TITLE
Remove logback.xml from moco-core distribution. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,12 @@ subprojects {
     }
 }
 
+project(':moco-core') {
+    jar {
+        exclude('logback.xml')
+    }
+}
+
 project(':moco-runner') {
 
     dependencies {


### PR DESCRIPTION
I agree with mkgarnek.

A library should not impose logging settings on the final products that will use it and logback can't work right with duplicate setting files.

The ubjar also has a logback.xml.It comes from moco-core resource.I am not sure it's necessary or not...
