### PR TITLE
readability improve

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoHandler.java
@@ -27,7 +27,8 @@ public class MocoHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest message) throws Exception {
-        closeIfNotKeepAlive(message, ctx.writeAndFlush(handleRequest(message)));
+    	FullHttpResponse response = handleRequest(message);
+        closeIfNotKeepAlive(message, ctx.writeAndFlush(response));
     }
 
     private FullHttpResponse handleRequest(FullHttpRequest message) {


### PR DESCRIPTION
因为handleRequest对于channelRead0来说是最重要的一个动作，所以把它单独用一行来强调，一点小的可读性改善。
