### PR TITLE
Add moco mapping rule in Junit @Test method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ reports
 *.output
 .gmoco_pid
 gmoco.log
+.project
+.classpath
+.settings/
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 }
 
 allprojects {
+    apply plugin: 'eclipse'
     apply plugin: 'idea'
     apply plugin: 'maven'
     apply plugin: 'signing'

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerBeforeClassTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerBeforeClassTest.java
@@ -1,11 +1,11 @@
 package com.github.dreamhead.moco;
 
-import static com.github.dreamhead.moco.Moco.httpserver;
 import static com.github.dreamhead.moco.Moco.by;
+import static com.github.dreamhead.moco.Moco.httpserver;
 import static com.github.dreamhead.moco.Moco.uri;
 import static com.github.dreamhead.moco.RemoteTestUtils.port;
-import static com.github.dreamhead.moco.RemoteTestUtils.root;
 import static com.github.dreamhead.moco.RemoteTestUtils.remoteUrl;
+import static com.github.dreamhead.moco.RemoteTestUtils.root;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -30,17 +30,22 @@ public class MocoRunnerBeforeClassTest {
     private static MocoTestHelper helper;
 
     @BeforeClass
-    public static void setup() {
+    public static void init() {
         server = httpserver(port());
         runner = Runner.runner(server);
+        helper = new MocoTestHelper();
+        setUpMockServices();
         runner.start();
+    }
+
+    protected static void setUpMockServices() {
         server.response(ROOT_RESPONSE);
         server.request(by(uri(LEVEL_ONE_URL))).response(LEVEL_ONE_RESPONSE);
-        helper = new MocoTestHelper();
+        server.request(by(uri(LEVEL_TWO_URL))).response(LEVEL_TWO_RESPONSE);
     }
 
     @AfterClass
-    public static void tearDown() {
+    public static void clean() {
         runner.stop();
     }
 
@@ -57,7 +62,6 @@ public class MocoRunnerBeforeClassTest {
 
     @Test
     public void should_work_for_level_two_url_in_test() throws IOException {
-        server.request(by(uri(LEVEL_TWO_URL))).response(LEVEL_TWO_RESPONSE);
         assertThat(helper.get(remoteUrl(port(), LEVEL_TWO_URL)),
                 is(LEVEL_TWO_RESPONSE));
     }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerBeforeClassTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerBeforeClassTest.java
@@ -1,0 +1,65 @@
+package com.github.dreamhead.moco;
+
+import static com.github.dreamhead.moco.Moco.httpserver;
+import static com.github.dreamhead.moco.Moco.by;
+import static com.github.dreamhead.moco.Moco.uri;
+import static com.github.dreamhead.moco.RemoteTestUtils.port;
+import static com.github.dreamhead.moco.RemoteTestUtils.root;
+import static com.github.dreamhead.moco.RemoteTestUtils.remoteUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.github.dreamhead.moco.helper.MocoTestHelper;
+
+public class MocoRunnerBeforeClassTest {
+
+    private static final String LEVEL_ONE_URL = "/1";
+    private static final String LEVEL_TWO_URL = LEVEL_ONE_URL + "/2";
+    private static final String LEVEL_ONE_RESPONSE = "levelone";
+    private static final String LEVEL_TWO_RESPONSE = "leveltwo";
+    private static final String ROOT_RESPONSE = "foo";
+
+    private static Runner runner;
+    private static HttpServer server;
+    private static MocoTestHelper helper;
+
+    @BeforeClass
+    public static void setup() {
+        server = httpserver(port());
+        runner = Runner.runner(server);
+        runner.start();
+        server.response(ROOT_RESPONSE);
+        server.request(by(uri(LEVEL_ONE_URL))).response(LEVEL_ONE_RESPONSE);
+        helper = new MocoTestHelper();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        runner.stop();
+    }
+
+    @Test
+    public void should_work_for_root() throws IOException {
+        assertThat(helper.get(root()), is(ROOT_RESPONSE));
+    }
+
+    @Test
+    public void should_work_for_level_one_url() throws IOException {
+        assertThat(helper.get(remoteUrl(port(), LEVEL_ONE_URL)),
+                is(LEVEL_ONE_RESPONSE));
+    }
+
+    @Test
+    public void should_work_for_level_two_url_in_test() throws IOException {
+        server.request(by(uri(LEVEL_TWO_URL))).response(LEVEL_TWO_RESPONSE);
+        assertThat(helper.get(remoteUrl(port(), LEVEL_TWO_URL)),
+                is(LEVEL_TWO_RESPONSE));
+    }
+
+}

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerTest.java
@@ -20,14 +20,12 @@ import static org.junit.Assert.assertThat;
 public class MocoRunnerTest {
     private Runner runner;
     private MocoTestHelper helper;
+    private HttpServer server;
 
     @Before
     public void setup() {
-        HttpServer server = httpserver(port());
-        server.response("foo");
-        server.request(by(uri("/test"))).response("bar");
+        server = httpserver(port());
         runner = Runner.runner(server);
-        runner.start();
         helper = new MocoTestHelper();
     }
 
@@ -38,11 +36,15 @@ public class MocoRunnerTest {
 
     @Test
     public void should_work_well() throws IOException {
+        server.response("foo");
+        runner.start();
         assertThat(helper.get(root()), is("foo"));
     }
 
     @Test
     public void should_work_well_for_sub_url() throws IOException {
+        server.request(by(uri("/test"))).response("bar");
+        runner.start();
         assertThat(helper.get(remoteUrl(port(), "/test")), is("bar"));
     }
 }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoRunnerTest.java
@@ -1,6 +1,7 @@
 package com.github.dreamhead.moco;
 
 import com.github.dreamhead.moco.helper.MocoTestHelper;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,7 +9,10 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static com.github.dreamhead.moco.Moco.httpserver;
+import static com.github.dreamhead.moco.Moco.uri;
+import static com.github.dreamhead.moco.Moco.by;
 import static com.github.dreamhead.moco.RemoteTestUtils.port;
+import static com.github.dreamhead.moco.RemoteTestUtils.remoteUrl;
 import static com.github.dreamhead.moco.RemoteTestUtils.root;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -21,6 +25,7 @@ public class MocoRunnerTest {
     public void setup() {
         HttpServer server = httpserver(port());
         server.response("foo");
+        server.request(by(uri("/test"))).response("bar");
         runner = Runner.runner(server);
         runner.start();
         helper = new MocoTestHelper();
@@ -34,5 +39,10 @@ public class MocoRunnerTest {
     @Test
     public void should_work_well() throws IOException {
         assertThat(helper.get(root()), is("foo"));
+    }
+
+    @Test
+    public void should_work_well_for_sub_url() throws IOException {
+        assertThat(helper.get(remoteUrl(port(), "/test")), is("bar"));
     }
 }


### PR DESCRIPTION
Hi Zheng Ye (@dreamhead),

I have been using the `moco` during my test recently, it really helps me a lot, thx for the wonderful `moco` framework. :+1: But I notice a small issue, when I want to setup a runner in `@BeforeClass` method, and put the mapping mock rule into the `@Test` method, it seems that it will not map the mock rule correctly, see test case in details. Is this an intended behaviour from `moco` such that you can only setup mapping mock rule before `@Test` method? 

I have added and a `MocoRunnerBeforeClassTest.java` test file to demonstrate my issue. I have added an Eclipse plugin for `gradle` as I am an Eclipse user. :smile: 

Thank you very much.

Best Regards,
GaoXiang