### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the old days, we just deployed another WAR to an application server, e.g. Jet
 
 * Run Moco http server
 ```shell
-java -jar moco-runner-<version>-standalone.jar http -p 12306 -c foo.json
+java -jar moco-runner-<version>-standalone.jar start -p 12306 -c foo.json
 ```
 
 * Now, open your favorite browser to visit http://localhost:12306 and you will see "Hello, Moco".


### PR DESCRIPTION
The command that is used to run Mock http server quickly described under Quick Start section is wrong, http should be start.
