### PR TITLE
Updated HTTP content dumper.

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/dumper/HttpDumpers.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/dumper/HttpDumpers.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.dumper;
 
 import com.github.dreamhead.moco.HttpMessage;
 import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
 import io.netty.util.internal.StringUtil;
 
 public class HttpDumpers {
@@ -24,7 +25,15 @@ public class HttpDumpers {
     }
 
     private static boolean isText(final String type) {
-        return type == null || type.startsWith("text") || type.endsWith("javascript") || type.endsWith("json") || type.endsWith("xml");
+        try {
+            MediaType mediaType = MediaType.parse(type);
+            return mediaType.is(MediaType.ANY_TEXT_TYPE)
+                    || mediaType.subtype().endsWith("javascript")
+                    || mediaType.subtype().endsWith("json")
+                    || mediaType.subtype().endsWith("xml");
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private static long getContentLength(final HttpMessage response, final long defaultValue) {

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoLogTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoLogTest.java
@@ -51,7 +51,7 @@ public class MocoLogTest {
         });
 
         String actual = Files.toString(file, Charset.defaultCharset());
-        assertThat(actual, containsString("0XCAFE"));
+        assertThat(actual, containsString("0XBABE"));
         assertThat(actual, containsString("0XCAFE"));
     }
 
@@ -69,7 +69,7 @@ public class MocoLogTest {
         });
 
         String actual = Files.toString(file, Charset.defaultCharset());
-        assertThat(actual, containsString("0XCAFE"));
+        assertThat(actual, containsString("0XBABE"));
         assertThat(actual, containsString("0XCAFE"));
     }
 
@@ -110,7 +110,7 @@ public class MocoLogTest {
         });
 
         String actual = Files.toString(file, Charset.defaultCharset());
-        assertThat(actual, containsString("0XCAFE"));
+        assertThat(actual, containsString("0XBABE"));
         assertThat(actual, containsString("0XCAFE"));
     }
 

--- a/moco-core/src/test/java/com/github/dreamhead/moco/dumper/HttpDumpersTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/dumper/HttpDumpersTest.java
@@ -1,0 +1,92 @@
+package com.github.dreamhead.moco.dumper;
+
+import com.github.dreamhead.moco.HttpMessage;
+import com.github.dreamhead.moco.model.DefaultHttpResponse;
+import com.github.dreamhead.moco.model.MessageContent;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
+import io.netty.util.internal.StringUtil;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.github.dreamhead.moco.dumper.HttpDumpers.asContent;
+import static java.util.Collections.EMPTY_MAP;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assert.assertThat;
+
+public class HttpDumpersTest {
+
+    private static final String MESSAGE_BODY = "test message body";
+    private static final String EXPECTED_MESSAGE_BODY = StringUtil.NEWLINE + StringUtil.NEWLINE + MESSAGE_BODY;
+    private static final String BINARY_CONTENT_MESSAGE = StringUtil.NEWLINE + StringUtil.NEWLINE + "<content is binary>";
+
+    @Test
+    public void should_parse_plain_text_media_type() throws Exception {
+        assertMessageContent("text/html", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_complete_text_media_type() throws Exception {
+        assertMessageContent("text/html; charset=ISO-8859-1", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_plain_json_media_type() throws Exception {
+        assertMessageContent("application/json", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_complete_json_media_type() throws Exception {
+        assertMessageContent("application/json; charset=ISO-8859-1", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_plain_javascript_media_type() throws Exception {
+        assertMessageContent("text/javascript", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_complete_javascript_media_type() throws Exception {
+        assertMessageContent("text/javascript; charset=UTF-8", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_plain_xml_media_type() throws Exception {
+        assertMessageContent("application/xml", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_parse_complete_xml_media_type() throws Exception {
+        assertMessageContent("application/rss+xml", EXPECTED_MESSAGE_BODY);
+    }
+
+    @Test
+    public void should_not_parse_binary_media_type() throws Exception {
+        assertMessageContent("image/jpeg", BINARY_CONTENT_MESSAGE);
+    }
+
+    @Test
+    public void should_not_parse_content_when_content_length_not_set() throws Exception {
+        assertThat(asContent(messageWithHeaders(EMPTY_MAP)), isEmptyString());
+    }
+
+    private void assertMessageContent(String mediaType, String expectedContent) {
+        assertThat(asContent(messageWithHeaders(defaultHeadersFor(mediaType))), is(expectedContent));
+    }
+
+    private HttpMessage messageWithHeaders(Map<String, String> headers) {
+        return DefaultHttpResponse.builder()
+                .withHeaders(headers)
+                .withContent(MessageContent.content(MESSAGE_BODY))
+                .build();
+    }
+
+    private Map<String, String> defaultHeadersFor(String mediaType) {
+        return ImmutableMap.<String, String>builder()
+                .put(HttpHeaders.CONTENT_LENGTH, String.valueOf(MESSAGE_BODY.length()))
+                .put(HttpHeaders.CONTENT_TYPE, mediaType)
+                .build();
+    }
+}

--- a/moco-core/src/test/java/com/github/dreamhead/moco/dumper/HttpDumpersTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/dumper/HttpDumpersTest.java
@@ -68,6 +68,7 @@ public class HttpDumpersTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void should_not_parse_content_when_content_length_not_set() throws Exception {
         assertThat(asContent(messageWithHeaders(EMPTY_MAP)), isEmptyString());
     }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/helper/MocoTestHelper.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/helper/MocoTestHelper.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.util.Map;
 
 import static com.google.common.io.ByteStreams.toByteArray;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 
 public class MocoTestHelper {
     private final Executor EXECUTOR;
@@ -73,7 +75,10 @@ public class MocoTestHelper {
     }
 
     public String postBytes(String url, byte[] bytes) throws IOException {
-        return EXECUTOR.execute(Request.Post(url).bodyByteArray(bytes)).returnContent().asString();
+        Request request = Request.Post(url)
+                .addHeader(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString())
+                .bodyByteArray(bytes);
+        return EXECUTOR.execute(request).returnContent().asString();
     }
 
     public String postStream(String url, InputStream stream) throws IOException {


### PR DESCRIPTION
I had the problem that the content of an HTTP message wasn't printed when the Content-Type header had the character set attached (i.e. "application/json; charset=ISO-8859-1"). HttpDumper could make use of guavas MediaType parser to have a stricter way of specifying which content is considered printable text.