### PR TITLE
Update script to remove expr warning on Mac

### DIFF
--- a/moco-shell/moco
+++ b/moco-shell/moco
@@ -102,7 +102,7 @@ function install {
 
 function load_current_version {
     read MOCO_STANDALONE CURRENT_VERSION < $VERSION_LOG_FILE
-    if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ];then
+    if [[ "$(uname)" -ne "Darwin" && "$(expr substr $(uname -s) 2 6)" == "CYGWIN"   ]];then
         MOCO_STANDALONE=`cygpath -m "$MOCO_STANDALONE"`
     fi
 }


### PR DESCRIPTION
Apperantly `expr` has a different syntax on Mac than any other platform, so use ` -ne Darwin` to exclude Mac first and then check for Cygwin