### PR TITLE
Rename variables  which hide the field declared and remove unused private fields

### DIFF
--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoPortTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoPortTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class MocoPortTest {
-    private HttpServer server;
+    
     private MocoTestHelper helper;
 
     @Before

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoSocketTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoSocketTest.java
@@ -82,10 +82,10 @@ public class MocoSocketTest {
     @Test
     public void should_log_request_and_response_into_file() throws Exception {
         File file = folder.newFile();
-        SocketServer server = socketServer(port(), log(file.getAbsolutePath()));
-        server.request(by("0XCAFE")).response(line("0XBABE"));
+        SocketServer socketServer = socketServer(port(), log(file.getAbsolutePath()));
+        socketServer.request(by("0XCAFE")).response(line("0XBABE"));
 
-        running(server, new Runnable() {
+        running(socketServer, new Runnable() {
             @Override
             public void run() throws Exception {
                 helper.connect();
@@ -102,10 +102,10 @@ public class MocoSocketTest {
     @Test
     public void should_monitor_socket_server_behavior() throws Exception {
         RequestHit hit = requestHit();
-        SocketServer server = socketServer(port(), hit);
-        server.request(by("0XCAFE")).response(line("0XBABE"));
+        SocketServer socketServer = socketServer(port(), hit);
+        socketServer.request(by("0XCAFE")).response(line("0XBABE"));
 
-        running(server, new Runnable() {
+        running(socketServer, new Runnable() {
             @Override
             public void run() throws Exception {
                 helper.connect();
@@ -119,13 +119,13 @@ public class MocoSocketTest {
 
     @Test
     public void should_create_socket_server_without_specific_port() throws Exception {
-        final SocketServer server = socketServer();
-        server.request(by("foo")).response(line("bar"));
+        final SocketServer socketServer = socketServer();
+        socketServer.request(by("foo")).response(line("bar"));
 
-        running(server, new Runnable() {
+        running(socketServer, new Runnable() {
             @Override
             public void run() throws Exception {
-                helper = new MocoSocketHelper(local(), server.port());
+                helper = new MocoSocketHelper(local(), socketServer.port());
                 helper.connect();
                 assertThat(helper.send("foo"), is("bar"));
                 helper.close();
@@ -136,13 +136,13 @@ public class MocoSocketTest {
     @Test
     public void should_verify_expected_request_and_log_at_same_time() throws Exception {
         RequestHit hit = requestHit();
-        final SocketServer server = socketServer(port(), hit, log());
-        server.request(by("foo")).response(line("bar"));
+        final SocketServer socketServer = socketServer(port(), hit, log());
+        socketServer.request(by("foo")).response(line("bar"));
 
-        running(server, new Runnable() {
+        running(socketServer, new Runnable() {
             @Override
             public void run() throws Exception {
-                helper = new MocoSocketHelper(local(), server.port());
+                helper = new MocoSocketHelper(local(), socketServer.port());
                 helper.connect();
                 assertThat(helper.send("foo"), is("bar"));
                 helper.close();

--- a/moco-runner/src/test/java/com/github/dreamhead/moco/MocoJsonSocketRunnerTest.java
+++ b/moco-runner/src/test/java/com/github/dreamhead/moco/MocoJsonSocketRunnerTest.java
@@ -40,10 +40,10 @@ public class MocoJsonSocketRunnerTest {
         running(server, new Runnable() {
             @Override
             public void run() throws Exception {
-                MocoSocketHelper helper = new MocoSocketHelper(local(), server.port());
-                helper.connect();
-                assertThat(helper.send("foo", 3), is("bar"));
-                helper.close();
+                MocoSocketHelper mocoSocketHelper = new MocoSocketHelper(local(), server.port());
+                mocoSocketHelper.connect();
+                assertThat(mocoSocketHelper.send("foo", 3), is("bar"));
+                mocoSocketHelper.close();
             }
         });
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - “ Local variables should not shadow class fields”. and Sonar rule squid:S1068 - "Unused private fields should be removed"
You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
Ayman Abdelghany.