### PR TITLE
Define and throw a dedicated exception instead of using a generic one.

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/HttpsCertificate.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/HttpsCertificate.java
@@ -44,7 +44,7 @@ public final class HttpsCertificate {
             serverContext.init(factory.getKeyManagers(), null, null);
             return serverContext;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to initialize the server-side SSLContext", e);
+            throw new MocoException("Failed to initialize the server-side SSLContext", e);
         } finally {
             Closeables.closeQuietly(is);
         }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/MocoException.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/MocoException.java
@@ -1,0 +1,20 @@
+package com.github.dreamhead.moco;
+
+/**
+ * Created by DevFactory on 1/22/16.
+ */
+public class MocoException extends RuntimeException {
+
+    public MocoException(final String message) {
+        super(message);
+    }
+
+    public MocoException(Throwable cause) {
+        super(cause);
+    }
+
+    public MocoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/moco-core/src/main/java/com/github/dreamhead/moco/action/MocoRequestAction.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/action/MocoRequestAction.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.action;
 
 import com.github.dreamhead.moco.MocoConfig;
 import com.github.dreamhead.moco.MocoEventAction;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.Request;
 import com.github.dreamhead.moco.resource.ContentResource;
 import com.github.dreamhead.moco.resource.Resource;
@@ -38,7 +39,7 @@ public class MocoRequestAction implements MocoEventAction {
         try {
             doExecute(client);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         } finally {
             try {
                 client.close();
@@ -69,7 +70,7 @@ public class MocoRequestAction implements MocoEventAction {
             return new HttpPost(url);
         }
 
-        throw new RuntimeException(format("unknown HTTP method: %s", method));
+        throw new MocoException(format("unknown HTTP method: %s", method));
     }
 
     @Override

--- a/moco-core/src/main/java/com/github/dreamhead/moco/extractor/FormsRequestExtractor.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/extractor/FormsRequestExtractor.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.extractor;
 
 import com.github.dreamhead.moco.HttpRequest;
 import com.github.dreamhead.moco.HttpRequestExtractor;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.model.DefaultHttpRequest;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -28,7 +29,7 @@ public class FormsRequestExtractor extends HttpRequestExtractor<ImmutableMap<Str
         } catch (HttpPostRequestDecoder.IncompatibleDataDecoderException idde) {
             return absent();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         } finally {
             if (decoder != null) {
                 decoder.destroy();

--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.handler;
 
 import com.github.dreamhead.moco.HttpRequest;
 import com.github.dreamhead.moco.HttpResponse;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.MutableHttpResponse;
 import com.github.dreamhead.moco.handler.failover.Failover;
 import com.github.dreamhead.moco.handler.failover.FailoverStrategy;
@@ -138,7 +139,7 @@ public abstract class AbstractProxyResponseHandler extends AbstractHttpResponseH
             return new HttpTrace(url.toString());
         }
 
-        throw new RuntimeException("unknown HTTP method");
+        throw new MocoException("unknown HTTP method");
     }
 
     protected HttpResponse setupResponse(final HttpRequest request,

--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/ResponseHandlers.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/ResponseHandlers.java
@@ -1,5 +1,6 @@
 package com.github.dreamhead.moco.handler;
 
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.ResponseHandler;
 import com.github.dreamhead.moco.resource.Resource;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +31,7 @@ public final class ResponseHandlers {
             Constructor[] constructors = clazz.getConstructors();
             return (ResponseHandler) constructors[0].newInstance(resource);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/failover/DefaultFailoverExecutor.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/failover/DefaultFailoverExecutor.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.github.dreamhead.moco.HttpRequest;
 import com.github.dreamhead.moco.HttpResponse;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.model.HttpRequestFailoverMatcher;
 import com.github.dreamhead.moco.model.Session;
 import com.google.common.base.Optional;
@@ -42,7 +43,7 @@ public class DefaultFailoverExecutor implements FailoverExecutor {
             Session targetSession = Session.newSession(request, httpResponse);
             writer.writeValue(this.file, prepareTargetSessions(targetSession));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 
@@ -74,7 +75,7 @@ public class DefaultFailoverExecutor implements FailoverExecutor {
             logger.error("exception found", jme);
             return of();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 
@@ -87,7 +88,7 @@ public class DefaultFailoverExecutor implements FailoverExecutor {
         }
 
         logger.error("No match request found: {}", request);
-        throw new RuntimeException("no failover response found");
+        throw new MocoException("no failover response found");
     }
 
     private Predicate<Session> isForRequest(final HttpRequest dumpedRequest) {

--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/failover/FailoverExecutor.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/failover/FailoverExecutor.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.handler.failover;
 
 import com.github.dreamhead.moco.HttpRequest;
 import com.github.dreamhead.moco.HttpResponse;
+import com.github.dreamhead.moco.MocoException;
 
 public interface FailoverExecutor {
     void onCompleteResponse(final HttpRequest request, final HttpResponse response);
@@ -14,7 +15,7 @@ public interface FailoverExecutor {
 
         @Override
         public HttpResponse failover(final HttpRequest request) {
-            throw new RuntimeException("no failover response found");
+            throw new MocoException("no failover response found");
         }
     };
 }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoClient.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoClient.java
@@ -1,5 +1,6 @@
 package com.github.dreamhead.moco.internal;
 
+import com.github.dreamhead.moco.MocoException;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -25,7 +26,7 @@ public class MocoClient {
             ChannelFuture future = channel.closeFuture().sync();
             future.addListener(ChannelFutureListener.CLOSE);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         } finally {
             group.shutdownGracefully();
         }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoServer.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoServer.java
@@ -1,5 +1,6 @@
 package com.github.dreamhead.moco.internal;
 
+import com.github.dreamhead.moco.MocoException;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -32,7 +33,7 @@ public class MocoServer {
             SocketAddress socketAddress = future.channel().localAddress();
             return ((InetSocketAddress) socketAddress).getPort();
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoSocketHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/MocoSocketHandler.java
@@ -1,9 +1,6 @@
 package com.github.dreamhead.moco.internal;
 
-import com.github.dreamhead.moco.MocoMonitor;
-import com.github.dreamhead.moco.SocketRequest;
-import com.github.dreamhead.moco.SocketResponse;
-import com.github.dreamhead.moco.SocketResponseSetting;
+import com.github.dreamhead.moco.*;
 import com.github.dreamhead.moco.model.DefaultSocketRequest;
 import com.github.dreamhead.moco.model.DefaultSocketResponse;
 import com.github.dreamhead.moco.model.MessageContent;
@@ -65,7 +62,7 @@ public class MocoSocketHandler extends SimpleChannelInboundHandler<ByteBuf> {
         }
 
         this.monitor.onUnexpectedMessage(context.getRequest());
-        throw new RuntimeException(format("No handler found for request: %s", context.getRequest().getContent()));
+        throw new MocoException(format("No handler found for request: %s", context.getRequest().getContent()));
     }
 
     @Override

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -3,10 +3,7 @@ package com.github.dreamhead.moco.matcher;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.dreamhead.moco.MocoConfig;
-import com.github.dreamhead.moco.Request;
-import com.github.dreamhead.moco.RequestExtractor;
-import com.github.dreamhead.moco.RequestMatcher;
+import com.github.dreamhead.moco.*;
 import com.github.dreamhead.moco.resource.Resource;
 import com.google.common.base.Optional;
 
@@ -39,7 +36,7 @@ public class JsonRequestMatcher extends AbstractRequestMatcher {
         } catch (JsonProcessingException jpe) {
             return false;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/XmlRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/XmlRequestMatcher.java
@@ -1,9 +1,6 @@
 package com.github.dreamhead.moco.matcher;
 
-import com.github.dreamhead.moco.MocoConfig;
-import com.github.dreamhead.moco.Request;
-import com.github.dreamhead.moco.RequestExtractor;
-import com.github.dreamhead.moco.RequestMatcher;
+import com.github.dreamhead.moco.*;
 import com.github.dreamhead.moco.extractor.XmlExtractorHelper;
 import com.github.dreamhead.moco.resource.Resource;
 import org.w3c.dom.Document;
@@ -97,7 +94,7 @@ public class XmlRequestMatcher extends AbstractRequestMatcher {
         try {
             return dbf.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 
@@ -109,7 +106,7 @@ public class XmlRequestMatcher extends AbstractRequestMatcher {
             trimNode(document);
             return document;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/model/MessageContent.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/model/MessageContent.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.dumper.MessageContentDeserializer;
 import com.github.dreamhead.moco.dumper.MessageContentSerializer;
 import com.google.common.base.Objects;
@@ -83,7 +84,7 @@ public class MessageContent {
                 this.content = toByteArray(is);
                 return this;
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new MocoException(e);
             }
         }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/monitor/FileLogWriter.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/monitor/FileLogWriter.java
@@ -1,5 +1,6 @@
 package com.github.dreamhead.moco.monitor;
 
+import com.github.dreamhead.moco.MocoException;
 import com.google.common.base.Optional;
 import com.google.common.io.Files;
 
@@ -20,7 +21,7 @@ public class FileLogWriter implements LogWriter {
         try {
             Files.append(content, file, charset.or(Charset.defaultCharset()));
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/mount/AbstractHttpContentResponseHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/mount/AbstractHttpContentResponseHandler.java
@@ -1,6 +1,7 @@
 package com.github.dreamhead.moco.mount;
 
 import com.github.dreamhead.moco.HttpRequest;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.Request;
 import com.github.dreamhead.moco.handler.AbstractContentResponseHandler;
 import com.github.dreamhead.moco.model.MessageContent;
@@ -11,7 +12,7 @@ public abstract class AbstractHttpContentResponseHandler extends AbstractContent
     @Override
     protected MessageContent responseContent(final Request request) {
         if (!HttpRequest.class.isInstance(request)) {
-            throw new RuntimeException("Only HTTP request is allowed");
+            throw new MocoException("Only HTTP request is allowed");
         }
 
         return responseContent((HttpRequest) request);

--- a/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/ClasspathFileResourceReader.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/ClasspathFileResourceReader.java
@@ -1,5 +1,6 @@
 package com.github.dreamhead.moco.resource.reader;
 
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.Request;
 import com.github.dreamhead.moco.resource.Resource;
 import com.google.common.base.Optional;
@@ -26,7 +27,7 @@ public class ClasspathFileResourceReader extends AbstractFileResourceReader {
         try {
             return toByteArray(resource.openStream());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/FileResourceReader.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/FileResourceReader.java
@@ -1,6 +1,7 @@
 package com.github.dreamhead.moco.resource.reader;
 
 import com.github.dreamhead.moco.MocoConfig;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.Request;
 import com.github.dreamhead.moco.resource.Resource;
 import com.google.common.base.Optional;
@@ -35,7 +36,7 @@ public class FileResourceReader extends AbstractFileResourceReader {
         try {
             return toByteArray(file);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/TemplateResourceReader.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/TemplateResourceReader.java
@@ -1,6 +1,7 @@
 package com.github.dreamhead.moco.resource.reader;
 
 import com.github.dreamhead.moco.HttpRequest;
+import com.github.dreamhead.moco.MocoException;
 import com.github.dreamhead.moco.Request;
 import com.github.dreamhead.moco.model.MessageContent;
 import com.github.dreamhead.moco.resource.ContentResource;
@@ -65,11 +66,11 @@ public class TemplateResourceReader implements ContentResourceReader {
             return content().withContent(stream.toByteArray()).build();
         } catch (ParseException e) {
             logger.error("Fail to parse template: {}", content.toString());
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         } catch (TemplateException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/util/Idles.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/util/Idles.java
@@ -1,5 +1,7 @@
 package com.github.dreamhead.moco.util;
 
+import com.github.dreamhead.moco.MocoException;
+
 import java.util.concurrent.TimeUnit;
 
 public final class Idles {
@@ -7,7 +9,7 @@ public final class Idles {
         try {
             unit.sleep(duration);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/util/Jsons.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/util/Jsons.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dreamhead.moco.MocoException;
 
 public final class Jsons {
     public static String toJson(final Object value) {
@@ -9,7 +10,7 @@ public final class Jsons {
         try {
             return mapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new MocoException(e);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00112 - “Generic exceptions should never be thrown”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S00112
Please let me know if you have any questions.
Ayman Abdelghany.