### PR TITLE
Link to maintained Scala wrapper

### DIFF
--- a/moco-doc/usage.md
+++ b/moco-doc/usage.md
@@ -255,4 +255,4 @@ It will download the latest moco automatically if you don't have locally.
 
 Scala fans can find Scala wrapper in
 
-https://github.com/nicholasren/moco-scala
+https://github.com/treppo/moco-scala


### PR DESCRIPTION
I forked Nicholas Ren's Scala wrapper for Moco a while ago, because it was not maintained
and it was not up–to–date any more. I'm maintaining the fork and thought it might
be helpful to link to it instead.