### PR TITLE
Can use WatchService API instead of monitor from commons-io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ allprojects {
 
 idea {
     project {
-        jdkName = JavaVersion.VERSION_1_6
-        languageLevel = JavaVersion.VERSION_1_6
+        jdkName = JavaVersion.VERSION_1_7
+        languageLevel = JavaVersion.VERSION_1_7
 
         vcs = "Git"
     }
@@ -24,8 +24,8 @@ subprojects {
     apply plugin: 'java'
     group = 'com.github.dreamhead'
     version = '0.11.0-SNAPSHOT'
-    sourceCompatibility = JavaVersion.VERSION_1_6
-    targetCompatibility = JavaVersion.VERSION_1_6
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
 
     repositories {
         jcenter()

--- a/moco-doc/cmd.md
+++ b/moco-doc/cmd.md
@@ -111,3 +111,15 @@ Then you can use the shutdown port to shutdown the running Moco instance.
 ```shell
 java -jar moco-runner-<version>-standalone.jar shutdown -s 9527
 ```
+
+## Watch Service
+
+Moco use monitor from commons-io to monitor file changes by default. You can change to WatchService API by adding `--watch-service` argument.
+
+The `--watch-service` argument works with `http`, `https` and `socket` server types:
+
+```shell
+java -jar moco-runner-<version>-standalone.jar http -p 12306 -c foo.json --watch-service
+```
+
+The WatchService API provide better performance and less compatibility. A known issue is that it won't work on Docker Toolbox above Win 7.

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/HttpArgs.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/HttpArgs.java
@@ -4,9 +4,9 @@ import com.github.dreamhead.moco.bootstrap.ServerType;
 
 public final class HttpArgs extends StartArgs {
     private HttpArgs(final Integer port, final Integer shutdownPort,
-                       final String configurationFile, final String globalSettings,
-                       final String env) {
-        super(ServerType.HTTP, port, shutdownPort, configurationFile, globalSettings, env, null);
+                     final String configurationFile, final String globalSettings,
+                     final String env, final boolean watchService) {
+        super(ServerType.HTTP, port, shutdownPort, configurationFile, globalSettings, env, null, watchService);
     }
 
     public static Builder httpArgs() {
@@ -19,6 +19,7 @@ public final class HttpArgs extends StartArgs {
         private String configurationFile;
         private String settings;
         private String env;
+        private boolean watchService;
 
         public Builder withPort(final Integer port) {
             this.port = port;
@@ -45,8 +46,13 @@ public final class HttpArgs extends StartArgs {
             return this;
         }
 
+        public Builder withWatchService(final boolean watchService) {
+            this.watchService = watchService;
+            return this;
+        }
+
         public HttpArgs build() {
-            return new HttpArgs(port, shutdownPort, configurationFile, settings, env);
+            return new HttpArgs(port, shutdownPort, configurationFile, settings, env, watchService);
         }
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/HttpsArgs.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/HttpsArgs.java
@@ -5,8 +5,9 @@ import com.github.dreamhead.moco.bootstrap.ServerType;
 
 public final class HttpsArgs extends StartArgs {
     private HttpsArgs(final Integer port, final Integer shutdownPort, final String configurationFile,
-                        final String globalSettings, final String env, final HttpsArg httpsArg) {
-        super(ServerType.HTTPS, port, shutdownPort, configurationFile, globalSettings, env, httpsArg);
+                      final String globalSettings, final String env, final HttpsArg httpsArg,
+                      final boolean watchService) {
+        super(ServerType.HTTPS, port, shutdownPort, configurationFile, globalSettings, env, httpsArg, watchService);
     }
 
     public static Builder httpsArgs() {
@@ -20,6 +21,7 @@ public final class HttpsArgs extends StartArgs {
         private String settings;
         private String env;
         private HttpsArg httpsArg;
+        private boolean watchService;
 
         public Builder withPort(final Integer port) {
             this.port = port;
@@ -51,8 +53,13 @@ public final class HttpsArgs extends StartArgs {
             return this;
         }
 
+        public Builder withWatchService(final boolean watchService) {
+            this.watchService = watchService;
+            return this;
+        }
+
         public HttpsArgs build() {
-            return new HttpsArgs(port, shutdownPort, configurationFile, settings, env, httpsArg);
+            return new HttpsArgs(port, shutdownPort, configurationFile, settings, env, httpsArg, watchService);
         }
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/SocketArgs.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/SocketArgs.java
@@ -3,8 +3,9 @@ package com.github.dreamhead.moco.bootstrap.arg;
 import static com.github.dreamhead.moco.bootstrap.ServerType.SOCKET;
 
 public final class SocketArgs extends StartArgs {
-    private SocketArgs(final Integer port, final Integer shutdownPort, final String configurationFile) {
-        super(SOCKET, port, shutdownPort, configurationFile, null, null, null);
+    private SocketArgs(final Integer port, final Integer shutdownPort, final String configurationFile,
+                       final boolean watchService) {
+        super(SOCKET, port, shutdownPort, configurationFile, null, null, null, watchService);
     }
 
     public static Builder socketArgs() {
@@ -15,6 +16,7 @@ public final class SocketArgs extends StartArgs {
         private Integer port;
         private Integer shutdownPort;
         private String configurationFile;
+        private boolean watchService;
 
         public Builder withPort(final Integer port) {
             this.port = port;
@@ -31,8 +33,13 @@ public final class SocketArgs extends StartArgs {
             return this;
         }
 
+        public Builder withWatchService(final boolean watchService) {
+            this.watchService = watchService;
+            return this;
+        }
+
         public SocketArgs build() {
-            return new SocketArgs(port, shutdownPort, configurationFile);
+            return new SocketArgs(port, shutdownPort, configurationFile, watchService);
         }
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/StartArgs.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/arg/StartArgs.java
@@ -16,10 +16,11 @@ public abstract class StartArgs extends ShutdownPortOption {
     private final Optional<String> settings;
     private final Optional<String> env;
     private final Optional<HttpsArg> httpsArg;
+    private final boolean watchService;
 
     protected StartArgs(final ServerType type, final Integer port, final Integer shutdownPort,
                         final String configurationFile, final String globalSettings,
-                        final String env, final HttpsArg httpsArg) {
+                        final String env, final HttpsArg httpsArg, final boolean watchService) {
         super(shutdownPort);
         this.type = type;
         this.port = fromNullable(port);
@@ -27,6 +28,7 @@ public abstract class StartArgs extends ShutdownPortOption {
         this.settings = fromNullable(globalSettings);
         this.env = fromNullable(env);
         this.httpsArg = fromNullable(httpsArg);
+        this.watchService = watchService;
     }
 
     public Optional<Integer> getPort() {
@@ -73,5 +75,9 @@ public abstract class StartArgs extends ShutdownPortOption {
 
     public boolean isSocket() {
         return this.type == ServerType.SOCKET;
+    }
+
+    public boolean isWatchService() {
+        return watchService;
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpArgsParser.java
@@ -15,6 +15,7 @@ public class HttpArgsParser extends StartArgsParser {
         String globalSettings = cmd.getOptionValue("g");
         String shutdownPort = cmd.getOptionValue("s");
         String env = cmd.getOptionValue("e");
+        boolean watchService = cmd.hasOption("watch-service");
 
         if (config == null && globalSettings == null) {
             throw new ParseArgException("config or global setting is required");
@@ -38,6 +39,7 @@ public class HttpArgsParser extends StartArgsParser {
                 .withConfigurationFile(config)
                 .withSettings(globalSettings)
                 .withEnv(env)
+                .withWatchService(watchService)
                 .build();
     }
 

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpArgsParser.java
@@ -5,7 +5,6 @@ import com.github.dreamhead.moco.bootstrap.arg.StartArgs;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
-import static com.github.dreamhead.moco.bootstrap.ShutdownPortOption.shutdownPortOption;
 import static com.github.dreamhead.moco.bootstrap.arg.HttpArgs.httpArgs;
 
 public class HttpArgsParser extends StartArgsParser {
@@ -44,12 +43,8 @@ public class HttpArgsParser extends StartArgsParser {
 
     @Override
     protected Options options() {
-        Options options = new Options();
-        options.addOption(configOption());
-        options.addOption(portOption());
-        options.addOption(shutdownPortOption());
-        options.addOption(settingsOption());
-        options.addOption(envOption());
-        return options;
+        return super.options()
+                .addOption(settingsOption())
+                .addOption(envOption());
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpsArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpsArgsParser.java
@@ -2,7 +2,6 @@ package com.github.dreamhead.moco.bootstrap.parser;
 
 import com.github.dreamhead.moco.bootstrap.HttpsArg;
 import com.github.dreamhead.moco.bootstrap.ParseArgException;
-import com.github.dreamhead.moco.bootstrap.ShutdownPortOption;
 import com.github.dreamhead.moco.bootstrap.arg.StartArgs;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -61,15 +60,11 @@ public class HttpsArgsParser extends StartArgsParser {
 
     @Override
     protected Options options() {
-        Options options = new Options();
-        options.addOption(configOption());
-        options.addOption(portOption());
-        options.addOption(ShutdownPortOption.shutdownPortOption());
-        options.addOption(settingsOption());
-        options.addOption(envOption());
-        options.addOption(httpsCertificate());
-        options.addOption(keyStore());
-        options.addOption(cert());
-        return options;
+        return super.options()
+                .addOption(settingsOption())
+                .addOption(envOption())
+                .addOption(httpsCertificate())
+                .addOption(keyStore())
+                .addOption(cert());
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpsArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/HttpsArgsParser.java
@@ -16,6 +16,7 @@ public class HttpsArgsParser extends StartArgsParser {
         String globalSettings = cmd.getOptionValue("g");
         String shutdownPort = cmd.getOptionValue("s");
         String env = cmd.getOptionValue("e");
+        boolean watchService = cmd.hasOption("watch-service");
 
         if (config == null && globalSettings == null) {
             throw new ParseArgException("config or global setting is required");
@@ -40,6 +41,7 @@ public class HttpsArgsParser extends StartArgsParser {
                 .withSettings(globalSettings)
                 .withEnv(env)
                 .withHttpsArg(httpsArg(cmd))
+                .withWatchService(watchService)
                 .build();
     }
 

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/SocketArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/SocketArgsParser.java
@@ -12,6 +12,7 @@ public class SocketArgsParser extends StartArgsParser {
         String port = cmd.getOptionValue("p");
         String config = cmd.getOptionValue("c");
         String shutdownPort = cmd.getOptionValue("s");
+        boolean watchService = cmd.hasOption("watch-service");
 
         if (config == null) {
             throw new ParseArgException("config is required");
@@ -25,6 +26,7 @@ public class SocketArgsParser extends StartArgsParser {
                 .withPort(getPort(port))
                 .withShutdownPort(getPort(shutdownPort))
                 .withConfigurationFile(config)
+                .withWatchService(watchService)
                 .build();
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/SocketArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/SocketArgsParser.java
@@ -3,9 +3,7 @@ package com.github.dreamhead.moco.bootstrap.parser;
 import com.github.dreamhead.moco.bootstrap.ParseArgException;
 import com.github.dreamhead.moco.bootstrap.arg.StartArgs;
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
 
-import static com.github.dreamhead.moco.bootstrap.ShutdownPortOption.shutdownPortOption;
 import static com.github.dreamhead.moco.bootstrap.arg.SocketArgs.socketArgs;
 
 public class SocketArgsParser extends StartArgsParser {
@@ -28,14 +26,5 @@ public class SocketArgsParser extends StartArgsParser {
                 .withShutdownPort(getPort(shutdownPort))
                 .withConfigurationFile(config)
                 .build();
-    }
-
-    @Override
-    protected Options options() {
-        Options options = new Options();
-        options.addOption(configOption());
-        options.addOption(portOption());
-        options.addOption(shutdownPortOption());
-        return options;
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/StartArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/StartArgsParser.java
@@ -2,15 +2,18 @@ package com.github.dreamhead.moco.bootstrap.parser;
 
 import com.github.dreamhead.moco.bootstrap.ParseArgException;
 import com.github.dreamhead.moco.bootstrap.arg.StartArgs;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.*;
+
+import static com.github.dreamhead.moco.bootstrap.ShutdownPortOption.shutdownPortOption;
 
 public abstract class StartArgsParser {
-    protected abstract Options options();
+    protected Options options() {
+        return new Options()
+                .addOption(configOption())
+                .addOption(portOption())
+                .addOption(shutdownPortOption());
+    }
+
     protected abstract StartArgs parseArgs(final CommandLine cmd);
 
     public StartArgs parse(final String[] args) {

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/StartArgsParser.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/bootstrap/parser/StartArgsParser.java
@@ -11,7 +11,8 @@ public abstract class StartArgsParser {
         return new Options()
                 .addOption(configOption())
                 .addOption(portOption())
-                .addOption(shutdownPortOption());
+                .addOption(shutdownPortOption())
+                .addOption(watchServiceOption());
     }
 
     protected abstract StartArgs parseArgs(final CommandLine cmd);
@@ -77,6 +78,10 @@ public abstract class StartArgsParser {
         option.setType(String.class);
         option.setRequired(false);
         return option;
+    }
+
+    Option watchServiceOption() {
+        return new Option(null, "watch-service", false, "Enable watch service");
     }
 
     public static Integer getPort(final String port) {

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/RunnerFactory.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/RunnerFactory.java
@@ -40,15 +40,24 @@ public class RunnerFactory {
         final File settingsFile = new File(startArgs.getSettings().get());
         final FileRunner fileRunner = createSettingFileRunner(settingsFile, startArgs);
         final SettingRunner runner = (SettingRunner) fileRunner.getRunner();
-        MocoRunnerWatcher fileMocoRunnerWatcher = monitorFactory.createSettingWatcher(settingsFile,
-                runner.getFiles(), fileRunner);
-        return new MonitorRunner(fileRunner, fileMocoRunnerWatcher);
+        final MocoRunnerWatcher mocoRunnerWatcher;
+        if (startArgs.isWatchService()) {
+            mocoRunnerWatcher = monitorFactory.createSettingWatcherBasedOnWatchService(settingsFile, runner.getFiles(), fileRunner);
+        } else {
+            mocoRunnerWatcher = monitorFactory.createSettingWatcher(settingsFile, runner.getFiles(), fileRunner);
+        }
+        return new MonitorRunner(fileRunner, mocoRunnerWatcher);
     }
 
     private Runner createDynamicConfigurationRunner(final StartArgs startArgs) {
         final File configuration = new File(startArgs.getConfigurationFile().get());
         final FileRunner fileRunner = createConfigurationFileRunner(configuration, startArgs);
-        MocoRunnerWatcher fileMocoRunnerWatcher = monitorFactory.createConfigurationWatcher(configuration, fileRunner);
-        return new MonitorRunner(fileRunner, fileMocoRunnerWatcher);
+        final MocoRunnerWatcher mocoRunnerWatcher;
+        if (startArgs.isWatchService()) {
+            mocoRunnerWatcher = monitorFactory.createConfigurationWatcherBasedOnWatchService(configuration, fileRunner);
+        } else {
+            mocoRunnerWatcher = monitorFactory.createConfigurationWatcher(configuration, fileRunner);
+        }
+        return new MonitorRunner(fileRunner, mocoRunnerWatcher);
     }
 }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/FileMocoRunnerWatcher.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/FileMocoRunnerWatcher.java
@@ -1,6 +1,8 @@
 package com.github.dreamhead.moco.runner.watcher;
 
+import com.google.common.base.Function;
 import org.apache.commons.io.monitor.FileAlterationListener;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
 import org.slf4j.Logger;
@@ -18,8 +20,13 @@ public class FileMocoRunnerWatcher implements MocoRunnerWatcher {
     private final FileAlterationMonitor monitor;
     private boolean running = false;
 
-    public FileMocoRunnerWatcher(final File file, final FileAlterationListener listener) {
-        this.monitor = monitorFile(file, listener);
+    public FileMocoRunnerWatcher(final File file, final Function<File, Void> listener) {
+        this.monitor = monitorFile(file, new FileAlterationListenerAdaptor() {
+            @Override
+            public void onFileChange(final File file) {
+                listener.apply(file);
+            }
+        });
     }
 
     public synchronized void startMonitor() {

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/FilesMocoRunnerWatcher.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/FilesMocoRunnerWatcher.java
@@ -1,7 +1,6 @@
 package com.github.dreamhead.moco.runner.watcher;
 
 import com.google.common.base.Function;
-import org.apache.commons.io.monitor.FileAlterationListener;
 
 import java.io.File;
 
@@ -10,7 +9,7 @@ import static com.google.common.collect.FluentIterable.from;
 public class FilesMocoRunnerWatcher implements MocoRunnerWatcher {
     private final Iterable<FileMocoRunnerWatcher> monitors;
 
-    public FilesMocoRunnerWatcher(final Iterable<File> files, final FileAlterationListener listener) {
+    public FilesMocoRunnerWatcher(final Iterable<File> files, final Function<File, Void> listener) {
         this.monitors = from(files).transform(new Function<File, FileMocoRunnerWatcher>() {
             @Override
             public FileMocoRunnerWatcher apply(final File file) {

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/MonitorFactory.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/MonitorFactory.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.List;
 
 public class MonitorFactory {
     private static Logger logger = LoggerFactory.getLogger(MonitorFactory.class);
@@ -28,13 +29,23 @@ public class MonitorFactory {
         return new FileMocoRunnerWatcher(configuration, createListener(fileRunner));
     }
 
+    public MocoRunnerWatcher createConfigurationWatcherBasedOnWatchService(final File configuration, final FileRunner fileRunner) {
+        return new WatchServiceMocoRunnerWatcher(ImmutableList.of(configuration), createListener(fileRunner));
+    }
+
     public MocoRunnerWatcher createSettingWatcher(final File settingsFile,
                                                   final Iterable<File> configurationFiles,
                                                   final FileRunner fileRunner) {
-        ImmutableList<File> files = ImmutableList.<File>builder().add(settingsFile).addAll(configurationFiles).build();
+        List<File> files = ImmutableList.<File>builder().add(settingsFile).addAll(configurationFiles).build();
         return new FilesMocoRunnerWatcher(files, createListener(fileRunner));
     }
 
+    public MocoRunnerWatcher createSettingWatcherBasedOnWatchService(final File settingsFile,
+                                                                     final Iterable<File> configurationFiles,
+                                                                     final FileRunner fileRunner) {
+        List<File> files = ImmutableList.<File>builder().add(settingsFile).addAll(configurationFiles).build();
+        return new WatchServiceMocoRunnerWatcher(files, createListener(fileRunner));
+    }
 
     private Function<File, Void> createListener(final FileRunner fileRunner) {
         return new Function<File, Void>() {

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/MonitorFactory.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/MonitorFactory.java
@@ -2,9 +2,9 @@ package com.github.dreamhead.moco.runner.watcher;
 
 import com.github.dreamhead.moco.runner.FileRunner;
 import com.github.dreamhead.moco.runner.Runner;
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,17 +35,20 @@ public class MonitorFactory {
         return new FilesMocoRunnerWatcher(files, createListener(fileRunner));
     }
 
-    private FileAlterationListenerAdaptor createListener(final FileRunner fileRunner) {
-        return new FileAlterationListenerAdaptor() {
+
+    private Function<File, Void> createListener(final FileRunner fileRunner) {
+        return new Function<File, Void>() {
             @Override
-            public void onFileChange(final File file) {
+            public Void apply(File file) {
                 logger.info("{} change detected.", file.getName());
                 try {
                     fileRunner.restart();
                 } catch (Exception e) {
                     logger.error("Fail to load configuration in {}.", file.getName());
                     logger.error(e.getMessage());
+                    logger.debug(e.getMessage(), e);
                 }
+                return null;
             }
         };
     }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/WatchServiceMocoRunnerWatcher.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/runner/watcher/WatchServiceMocoRunnerWatcher.java
@@ -1,0 +1,103 @@
+package com.github.dreamhead.moco.runner.watcher;
+
+import com.google.common.base.Function;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Collection;
+import java.util.List;
+
+import static com.sun.nio.file.SensitivityWatchEventModifier.HIGH;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+public class WatchServiceMocoRunnerWatcher implements MocoRunnerWatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(WatchServiceMocoRunnerWatcher.class);
+
+    private final List<File> files;
+    private final Function<File, Void> listener;
+    private final Multimap<WatchKey, Path> keys = HashMultimap.create();
+    private boolean running = false;
+    private WatchService watcher;
+
+    WatchServiceMocoRunnerWatcher(List<File> files, Function<File, Void> listener) {
+        this.files = files;
+        this.listener = listener;
+    }
+
+    @Override
+    public synchronized void startMonitor() {
+        if (running) {
+            throw new IllegalStateException();
+        }
+
+        try {
+            watcher = FileSystems.getDefault().newWatchService();
+            for (File file : files) {
+                // the reason use HIGH: http://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else
+                final WatchKey key = directoryOf(file).register(watcher, new WatchEvent.Kind[]{ENTRY_MODIFY}, HIGH);
+                keys.put(key, file.toPath());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        new Thread(createRunnable()).start();
+        running = true;
+    }
+
+    @Override
+    public synchronized void stopMonitor() {
+        if (running) {
+            try {
+                watcher.close();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+            keys.clear();
+            running = false;
+        }
+    }
+
+    private Runnable createRunnable() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                while (running) {
+                    loop();
+                }
+            }
+        };
+    }
+
+    private void loop() {
+        final WatchKey key;
+        try {
+            key = watcher.take();
+        } catch (Exception e) {
+            logger.debug(e.getMessage(), e);
+            return;
+        }
+
+        final Collection<Path> paths = keys.get(key);
+        for (WatchEvent<?> event : key.pollEvents()) {
+            final Path context = (Path) event.context();
+            for (Path path : paths) {
+                if (path.endsWith(context)) {
+                    listener.apply(path.toFile());
+                    break;
+                }
+            }
+        }
+        key.reset();
+    }
+
+    private Path directoryOf(File file) {
+        final Path parent = file.toPath().getParent();
+        return parent == null ? Paths.get(".") : parent;
+    }
+}

--- a/moco-runner/src/test/java/com/github/dreamhead/moco/bootstrap/StartArgsTest.java
+++ b/moco-runner/src/test/java/com/github/dreamhead/moco/bootstrap/StartArgsTest.java
@@ -2,6 +2,7 @@ package com.github.dreamhead.moco.bootstrap;
 
 import com.github.dreamhead.moco.bootstrap.arg.StartArgs;
 import com.github.dreamhead.moco.bootstrap.parser.HttpArgsParser;
+import com.github.dreamhead.moco.bootstrap.parser.HttpsArgsParser;
 import com.github.dreamhead.moco.bootstrap.parser.SocketArgsParser;
 import com.github.dreamhead.moco.bootstrap.parser.StartArgsParser;
 import com.google.common.base.Optional;
@@ -70,5 +71,29 @@ public class StartArgsTest {
     public void should_parse_socket() {
         StartArgs args = new SocketArgsParser().parse(new String[]{"start", "-c", "foo.json"});
         assertThat(args.isSocket(), is(true));
+    }
+
+    @Test
+    public void should_parse_with_default_watch_service() {
+        StartArgs args = startArgsParser.parse(new String[]{"start", "-c", "foo.json"});
+        assertThat(args.isWatchService(), is(false));
+    }
+
+    @Test
+    public void should_parse_watch_service() throws Exception {
+        StartArgs args = startArgsParser.parse(new String[]{"start", "--watch-service", "-c", "foo.json"});
+        assertThat(args.isWatchService(), is(true));
+    }
+
+    @Test
+    public void should_parse_socket_watch_service() throws Exception {
+        StartArgs args = new SocketArgsParser().parse(new String[]{"socket", "--watch-service", "-c", "foo.json"});
+        assertThat(args.isWatchService(), is(true));
+    }
+
+    @Test
+    public void should_parse_https_watch_service() throws Exception {
+        StartArgs args = new HttpsArgsParser().parse(new String[]{"https", "--watch-service", "-c", "foo.json", "--https", "/path/to/cert.jks", "--cert", "mocohttps", "--keystore", "mocohttps"});
+        assertThat(args.isWatchService(), is(true));
     }
 }


### PR DESCRIPTION
the monitor from commons-io cause a high CPU usage (com.docker.hyperkit and com.docker.osxfs use 400% on a MacBook Pro) on Docker for Mac

see https://github.com/docker/for-mac/issues/82#issuecomment-250556552

using Watch Service can reduce the high CPU usage (from 400% to 2%)
