### PR TITLE
fix proxy requests with body bug

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
@@ -111,6 +111,10 @@ public abstract class AbstractProxyResponseHandler extends AbstractHttpResponseH
             entityRequest.setEntity(createEntity(request.content(), contentLength));
         }
 
+        // apache httpclient will automatically set content-length header if body length greater than 0
+        // so we should remove it from headers to prevent "org.apache.http.ProtocolException: Content-Length header already present" error.
+        remoteRequest.removeHeaders("content-type");
+
         return remoteRequest;
     }
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/handler/AbstractProxyResponseHandler.java
@@ -113,7 +113,7 @@ public abstract class AbstractProxyResponseHandler extends AbstractHttpResponseH
 
         // apache httpclient will automatically set content-length header if body length greater than 0
         // so we should remove it from headers to prevent "org.apache.http.ProtocolException: Content-Length header already present" error.
-        remoteRequest.removeHeaders("content-type");
+        remoteRequest.removeHeaders("content-length");
 
         return remoteRequest;
     }


### PR DESCRIPTION
apache httpclient will automatically set content-length header if body length greater than 0, 
so we should remove it from headers to prevent "org.apache.http.ProtocolException: Content-Length header already present" error.

fix #224 