### PR TITLE
added support to get random numbers with special range

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/TemplateResourceReader.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/resource/reader/TemplateResourceReader.java
@@ -156,9 +156,10 @@ public class TemplateResourceReader implements ContentResourceReader {
     private static class RandomMethod implements TemplateMethodModelEx {
         @Override
         public Object exec(final List arguments) {
+            Optional<Long> start = getStart(arguments);
             Optional<Long> range = getRange(arguments);
             Optional<? extends NumberFormat> format = getFormat(arguments);
-            double result = new Random().nextDouble() * range.orElse(1L);
+            double result = start.orElse(0L)+new Random().nextDouble() * range.orElse(1L);
 
             if (format.isPresent()) {
                 return format.get().format(result);
@@ -185,22 +186,40 @@ public class TemplateResourceReader implements ContentResourceReader {
             if (arguments.size() <= 0) {
                 return Optional.empty();
             }
+            Object first = arguments.get(0);
+            Object second = arguments.size()>=2?arguments.get(1):Optional.empty();
 
-            Object range = arguments.get(0);
-            if (range instanceof SimpleNumber) {
-                return getRange((SimpleNumber) range);
+            if (first instanceof SimpleNumber&&second instanceof SimpleNumber) {
+                return getRange((SimpleNumber) first,(SimpleNumber)second);
             }
-
+            if (first instanceof SimpleNumber) {
+                return getRange(new SimpleNumber(0L),(SimpleNumber) first);
+            }
             return Optional.empty();
         }
 
-        private Optional<Long> getRange(final SimpleNumber range) {
-            long reference = range.getAsNumber().longValue();
-            if (reference <= 0) {
-                throw new IllegalArgumentException("Random range should be greater than 0");
+        private Optional<Long> getRange(final SimpleNumber start, final SimpleNumber end) {
+            long startReference = start.getAsNumber().longValue();
+            long endReference = end.getAsNumber().longValue();
+            long rangeReference =endReference-startReference;
+
+            if (rangeReference<= 0) {
+                throw new IllegalArgumentException("Random-end should be greater than random-start(default 0)");
             }
 
-            return Optional.of(reference);
+            return Optional.of(rangeReference);
+        }
+        private Optional<Long> getStart(final List<?> arguments) {
+
+            if(arguments.size() >=2){
+                Object start = arguments.get(0);
+                Object end = arguments.get(0);
+                if (start instanceof SimpleNumber&&end instanceof SimpleNumber) {
+                    return Optional.of(((SimpleNumber)start).getAsNumber().longValue());
+                }
+            }
+
+            return Optional.empty();
         }
     }
 }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoTemplateTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoTemplateTest.java
@@ -370,6 +370,22 @@ public class MocoTemplateTest extends AbstractMocoHttpTest {
     }
 
     @Test
+    public void should_generate_response_with_random_with_special_range() throws Exception {
+        server.request(by(uri("/random"))).response(template("${random(99,100)}"));
+
+        running(server, () -> {
+            String response = helper.get(remoteUrl("/random"));
+            try {
+                double result = Double.parseDouble(response);
+                assertThat(result, lessThan(100d));
+                assertThat(result, greaterThan(99d));
+            } catch (NumberFormatException e) {
+                fail();
+            }
+        });
+    }
+
+    @Test
     public void should_generate_response_with_random_with_data_format() throws Exception {
         server.request(by(uri("/random"))).response(template("${random('###.######')}"));
 
@@ -406,6 +422,24 @@ public class MocoTemplateTest extends AbstractMocoHttpTest {
     }
 
     @Test
+    public void should_generate_response_with_random_with_special_range_and_data_format() throws Exception {
+        server.request(by(uri("/random"))).response(template("${random(99,100, '###.######')}"));
+
+        running(server, () -> {
+            String response = helper.get(remoteUrl("/random"));
+            try {
+                double result = Double.parseDouble(response);
+                assertThat(result, lessThan(100d));
+                assertThat(result, greaterThan(99d));
+                String target = Iterables.get(Splitter.on('.').split(response), 1);
+                assertThat(target.length(), lessThanOrEqualTo(6));
+            } catch (NumberFormatException e) {
+                fail();
+            }
+        });
+    }
+
+    @Test
     public void should_throw_exception_for_random_with_range_less_than_0() throws Exception {
         server.request(by(uri("/template"))).response(template("${random(-10)}"));
 
@@ -414,7 +448,15 @@ public class MocoTemplateTest extends AbstractMocoHttpTest {
             assertThat(response.getStatusLine().getStatusCode(), is(400));
         });
     }
+    @Test
+    public void should_throw_exception_for_random_with_start_greater_than_end() throws Exception {
+        server.request(by(uri("/template"))).response(template("${random(100,99)}"));
 
+        running(server, () -> {
+            HttpResponse response = helper.getResponse(remoteUrl("/template"));
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+        });
+    }
     @Test
     public void should_return_json() throws Exception {
         server.request(by(uri("/template"))).response(template("${req.json.code} ${req.json.message}"));


### PR DESCRIPTION
you can get  random number with special range . 

```java
 server.request(by(uri("/random"))).response(template("${random(99,100)}"));

        running(server, () -> {
            String response = helper.get(remoteUrl("/random"));
            try {
                double result = Double.parseDouble(response);
                assertThat(result, lessThan(100d));
                assertThat(result, greaterThan(99d));
                System.out.println(result);
            } catch (NumberFormatException e) {
                fail();
            }
        });
```
```text
99.13
Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)
```