### PR TITLE
added json struct match support in java

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
@@ -202,6 +202,11 @@ public final class Moco {
         return ApiUtils.by(extractor(resource.id()), resource);
     }
 
+    public static RequestMatcher as(final Resource resource) {
+        checkNotNull(resource, "Resource should not be null");
+        return ApiUtils.as(extractor(resource.id()), resource);
+    }
+
     public static <T> RequestMatcher eq(final RequestExtractor<T> extractor, final String expected) {
         return eq(checkNotNull(extractor, "Extractor should not be null"), text(checkNotNull(expected, "Expected content should not be null")));
     }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
@@ -91,6 +91,14 @@ public final class ApiUtils {
         return new EqRequestMatcher<>(extractor, expected);
     }
 
+    public static <T> RequestMatcher as(final RequestExtractor<T> extractor, final Resource expected) {
+        if ("json".equalsIgnoreCase(expected.id())) {
+            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, JsonRequestMatcher.JsonMatchMode.STRUCT);
+        }
+
+        return new EqRequestMatcher<>(extractor, expected);
+    }
+
     public static ContentResource file(final Resource filename, final Charset charset) {
         return fileResource(checkNotNull(filename, "Filename should not be null"), charset, null);
     }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -10,16 +10,24 @@ import com.github.dreamhead.moco.extractor.ContentRequestExtractor;
 import com.github.dreamhead.moco.model.MessageContent;
 import com.github.dreamhead.moco.resource.Resource;
 
+import java.util.Iterator;
 import java.util.Optional;
+
 
 public final class JsonRequestMatcher extends AbstractRequestMatcher {
     private final ContentRequestExtractor extractor;
     private final ObjectMapper mapper;
     private final Resource expected;
+    private final JsonMatchMode matchMode;
 
     public JsonRequestMatcher(final Resource expected, final ContentRequestExtractor extractor) {
+        this(expected, extractor, JsonMatchMode.CONTENT);
+    }
+
+    public JsonRequestMatcher(final Resource expected, final ContentRequestExtractor extractor, JsonMatchMode matchMode) {
         this.extractor = extractor;
         this.expected = expected;
+        this.matchMode = matchMode;
         this.mapper = new ObjectMapper();
     }
 
@@ -35,10 +43,63 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
         try {
             JsonNode requestNode = mapper.readTree(content.toString());
             JsonNode resourceNode = mapper.readTree(expected.readFor(request).toString());
-            return requestNode.equals(resourceNode);
+            switch (this.matchMode) {
+                case STRUCT:
+                    return doStructMatch(requestNode, resourceNode);
+//                case REGEX :
+//                   return doRegexMatch(requestNode,resourceNode);
+                default:
+                    return doContentMatch(requestNode, resourceNode);
+            }
         } catch (JsonProcessingException jpe) {
             return false;
         }
+    }
+
+    private boolean doContentMatch(final JsonNode requestNode, final JsonNode resourceNode) {
+        return requestNode.equals(resourceNode);
+    }
+
+    private boolean doStructMatch(final JsonNode requestNode, final JsonNode resourceNode) {
+
+        if (requestNode == null) {
+            return false;
+        }
+        if (resourceNode.isNull()) {
+            return true;
+        }
+        if (requestNode.isNumber() && resourceNode.isNumber()) {
+            return true;
+        }
+        if (requestNode.isBoolean() && resourceNode.isBoolean()) {
+            return true;
+        }
+        if (requestNode.isTextual() && resourceNode.isTextual()) {
+            return true;
+        }
+        if (requestNode.isObject() && resourceNode.isObject()) {
+
+            for (Iterator<String> it = resourceNode.fieldNames(); it.hasNext(); ) {
+                String name = it.next();
+                if (!doStructMatch(requestNode.get(name), resourceNode.get(name))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (requestNode.isArray() && resourceNode.isArray()) {
+            if (requestNode.isEmpty()) {
+                return true;
+            }
+            JsonNode templateNode = requestNode.get(0);
+            for (JsonNode elementNode : resourceNode) {
+                if (!(doStructMatch(templateNode, elementNode))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -48,6 +109,14 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
             return this;
         }
 
-        return new JsonRequestMatcher(appliedResource, this.extractor);
+        return new JsonRequestMatcher(appliedResource, this.extractor, this.matchMode);
+    }
+
+
+    public enum JsonMatchMode {
+        //matched pattern
+        CONTENT,
+        STRUCT,
+        REGEX
     }
 }

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoJsonTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoJsonTest.java
@@ -25,6 +25,7 @@ import static com.github.dreamhead.moco.Moco.pathResource;
 import static com.github.dreamhead.moco.Moco.post;
 import static com.github.dreamhead.moco.Moco.text;
 import static com.github.dreamhead.moco.Moco.uri;
+import static com.github.dreamhead.moco.Moco.as;
 import static com.github.dreamhead.moco.Runner.running;
 import static com.github.dreamhead.moco.helper.RemoteTestUtils.port;
 import static com.github.dreamhead.moco.helper.RemoteTestUtils.remoteUrl;
@@ -42,7 +43,7 @@ public class MocoJsonTest extends AbstractMocoHttpTest {
         server.request(eq(jsonPath("$.book.price"), "1")).response("jsonpath match success");
         running(server, () ->
                 assertThat(helper.postContent(root(), "{\"book\":{\"price\":\"1\"}}"),
-                is("jsonpath match success")));
+                        is("jsonpath match success")));
     }
 
     @Test(expected = HttpResponseException.class)
@@ -80,8 +81,26 @@ public class MocoJsonTest extends AbstractMocoHttpTest {
     @Test
     public void should_match_same_structure_json() throws Exception {
         final String jsonText = Jsons.toJson(of("foo", "bar"));
-        server.request(by(json(jsonText))).response("foo");
-        running(server, () -> assertThat(helper.postContent(root(), jsonText), is("foo")));
+        final String jsonText2 = Jsons.toJson(of("foo", "bar2"));
+        server.request(as(json(jsonText))).response("foo");
+        running(server, () -> assertThat(helper.postContent(root(), jsonText2), is("foo")));
+    }
+
+    @Test
+    public void should_match_same_structure_json_with_resource() throws Exception {
+        final String jsonContent = "{\"foo\":\"bar\"}";
+        server.request(as(json(jsonContent))).response("foo");
+        running(server, () -> assertThat(helper.postContent(root(), "{\"foo\":\"bar2\"}"), is("foo")));
+    }
+
+    @Test
+    public void should_match_same_structure_POJO_json_resource() throws Exception {
+        PlainA pojo = new PlainA();
+        pojo.code = 1;
+        pojo.message = "message";
+
+        server.request(as(Moco.json(pojo))).response("foo");
+        running(server, () -> assertThat(helper.postContent(root(), "{\n\t\"code\":2,\n\t\"message\":\"information\"\n}"), is("foo")));
     }
 
     @Test


### PR DESCRIPTION
```java
  @Test
    public void should_match_same_structure_json() throws Exception {
        final String jsonText = Jsons.toJson(of("foo", "bar"));
        final String jsonText2 = Jsons.toJson(of("foo", "bar2"));
        server.request(as(json(jsonText))).response("foo");
        running(server, () -> assertThat(helper.postContent(root(), jsonText2), is("foo")));
    }
```
result:
```text
Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)
```