### PR TITLE
added rule match

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
                 "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion",
                 "org.apache.httpcomponents:httpclient:$httpComponentVersion",
                 "com.jayway.jsonpath:json-path:$jsonpathVersion",
+                "org.springframework:spring-expression:$SpELVersion",
                 "org.freemarker:freemarker:$freemarkerVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion"
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,4 @@ commonsCliVersion=1.4
 proguardVersion=7.1.1
 websocketVersion=2.0.0
 tyrusClientVersion=2.0.0
+SpELVersion=5.3.9

--- a/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
@@ -202,9 +202,14 @@ public final class Moco {
         return ApiUtils.by(extractor(resource.id()), resource);
     }
 
+    public static RequestMatcher as(final Resource resource, Boolean isRuleMatch) {
+        checkNotNull(resource, "Resource should not be null");
+        return ApiUtils.as(extractor(resource.id()), resource, isRuleMatch);
+    }
+
     public static RequestMatcher as(final Resource resource) {
         checkNotNull(resource, "Resource should not be null");
-        return ApiUtils.as(extractor(resource.id()), resource);
+        return ApiUtils.as(extractor(resource.id()), resource, false);
     }
 
     public static <T> RequestMatcher eq(final RequestExtractor<T> extractor, final String expected) {

--- a/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/Moco.java
@@ -202,14 +202,19 @@ public final class Moco {
         return ApiUtils.by(extractor(resource.id()), resource);
     }
 
-    public static RequestMatcher as(final Resource resource, Boolean isRuleMatch) {
-        checkNotNull(resource, "Resource should not be null");
-        return ApiUtils.as(extractor(resource.id()), resource, isRuleMatch);
-    }
-
     public static RequestMatcher as(final Resource resource) {
         checkNotNull(resource, "Resource should not be null");
-        return ApiUtils.as(extractor(resource.id()), resource, false);
+        return ApiUtils.as(extractor(resource.id()), resource);
+    }
+
+    public static RequestMatcher rule(final Resource resource) {
+        checkNotNull(resource, "Resource should not be null");
+        return ApiUtils.rule(extractor(resource.id()), resource);
+    }
+
+    public static <T> RequestMatcher rule(final RequestExtractor<T> extractor, final String expected) {
+        return ApiUtils.rule(checkNotNull(extractor, "Extractor should not be null"),
+                text(checkNotNullOrEmpty(expected, "Expected resource should not be null")));
     }
 
     public static <T> RequestMatcher eq(final RequestExtractor<T> extractor, final String expected) {

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
@@ -8,12 +8,7 @@ import com.github.dreamhead.moco.ResponseHandler;
 import com.github.dreamhead.moco.extractor.ContentRequestExtractor;
 import com.github.dreamhead.moco.handler.failover.DefaultFailoverExecutor;
 import com.github.dreamhead.moco.handler.failover.FailoverExecutor;
-import com.github.dreamhead.moco.matcher.ContainMatcher;
-import com.github.dreamhead.moco.matcher.EndsWithMatcher;
-import com.github.dreamhead.moco.matcher.EqRequestMatcher;
-import com.github.dreamhead.moco.matcher.JsonRequestMatcher;
-import com.github.dreamhead.moco.matcher.MatchMatcher;
-import com.github.dreamhead.moco.matcher.StartsWithMatcher;
+import com.github.dreamhead.moco.matcher.*;
 import com.github.dreamhead.moco.monitor.CompositeMonitor;
 import com.github.dreamhead.moco.monitor.DefaultLogFormatter;
 import com.github.dreamhead.moco.monitor.FileLogWriter;
@@ -91,13 +86,22 @@ public final class ApiUtils {
         return new EqRequestMatcher<>(extractor, expected);
     }
 
-    public static <T> RequestMatcher as(final RequestExtractor<T> extractor, final Resource expected, final Boolean isRuleMatch) {
+    public static <T> RequestMatcher as(final RequestExtractor<T> extractor, final Resource expected) {
         if ("json".equalsIgnoreCase(expected.id())) {
 
-            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, isRuleMatch ? JsonRequestMatcher.JsonMatchMode.RULE : JsonRequestMatcher.JsonMatchMode.STRUCT);
+            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, JsonRequestMatcher.JsonMatchMode.STRUCT);
         }
 
         return new EqRequestMatcher<>(extractor, expected);
+    }
+
+    public static <T> RequestMatcher rule(final RequestExtractor<T> extractor, final Resource expected) {
+        if ("json".equalsIgnoreCase(expected.id())) {
+
+            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, JsonRequestMatcher.JsonMatchMode.RULE);
+        }
+
+        return new RuleRequestMatcher<>(expected, extractor);
     }
 
     public static ContentResource file(final Resource filename, final Charset charset) {

--- a/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/internal/ApiUtils.java
@@ -91,9 +91,10 @@ public final class ApiUtils {
         return new EqRequestMatcher<>(extractor, expected);
     }
 
-    public static <T> RequestMatcher as(final RequestExtractor<T> extractor, final Resource expected) {
+    public static <T> RequestMatcher as(final RequestExtractor<T> extractor, final Resource expected, final Boolean isRuleMatch) {
         if ("json".equalsIgnoreCase(expected.id())) {
-            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, JsonRequestMatcher.JsonMatchMode.STRUCT);
+
+            return new JsonRequestMatcher(expected, (ContentRequestExtractor) extractor, isRuleMatch ? JsonRequestMatcher.JsonMatchMode.RULE : JsonRequestMatcher.JsonMatchMode.STRUCT);
         }
 
         return new EqRequestMatcher<>(extractor, expected);

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -96,9 +96,9 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
             if (requestNode.isEmpty()) {
                 return true;
             }
-            JsonNode templateNode = requestNode.get(0);
-            for (JsonNode elementNode : resourceNode) {
-                if (!(doStructMatch(templateNode, elementNode))) {
+            JsonNode templateNode = resourceNode.get(0);
+            for (JsonNode elementNode : requestNode) {
+                if (!(doStructMatch(elementNode, templateNode))) {
                     return false;
                 }
             }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -112,7 +112,7 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
         return new JsonRequestMatcher(appliedResource, this.extractor, this.matchMode);
     }
 
-    private boolean doRuleMatch(final JsonNode requestNode, final JsonNode resourceNode, Request request) {
+    private boolean doRuleMatch(final JsonNode requestNode, final JsonNode resourceNode, final Request request) {
 
         if (requestNode == null || resourceNode.isNull()) {
             return true;

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -114,10 +114,12 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
 
     private boolean doRuleMatch(final JsonNode requestNode, final JsonNode resourceNode, final Request request) {
 
-        if (requestNode == null || resourceNode.isNull()) {
+        if (resourceNode.isNull()) {
             return true;
         }
-
+        if (requestNode == null) {
+            return false;
+        }
         // If it is a JSON String value,it will be as a expression
         if (resourceNode.isTextual()) {
 

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonRequestMatcher.java
@@ -52,7 +52,7 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
                 case STRUCT:
                     return doStructMatch(requestNode, resourceNode);
                 case RULE:
-                    return doRuleMatch(requestNode, resourceNode);
+                    return doRuleMatch(requestNode, resourceNode, request);
                 default:
                     return doContentMatch(requestNode, resourceNode);
             }
@@ -117,7 +117,7 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
         return new JsonRequestMatcher(appliedResource, this.extractor, this.matchMode);
     }
 
-    private boolean doRuleMatch(JsonNode requestNode, final JsonNode resourceNode) {
+    private boolean doRuleMatch(JsonNode requestNode, final JsonNode resourceNode, Request request) {
 
         if (resourceNode.isNull()) {
             return true;
@@ -133,6 +133,8 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
             Expression exp = parser.parseExpression(resourceNode.asText());
 
             context.setVariable("value", transform(requestNode));
+
+            context.setVariable("request", request);
 
             return Optional.ofNullable(exp.getValue(context, Boolean.class)).orElse(false);
 
@@ -150,7 +152,7 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
 
             for (Iterator<String> it = resourceNode.fieldNames(); it.hasNext(); ) {
                 String name = it.next();
-                if (!doRuleMatch(requestNode.get(name), resourceNode.get(name))) {
+                if (!doRuleMatch(requestNode.get(name), resourceNode.get(name),request)) {
                     return false;
                 }
             }
@@ -164,7 +166,7 @@ public final class JsonRequestMatcher extends AbstractRequestMatcher {
             }
             JsonNode templateNode = resourceNode.get(0);
             for (JsonNode elementNode : resourceNode) {
-                if (!(doRuleMatch(elementNode, templateNode))) {
+                if (!(doRuleMatch(elementNode, templateNode,request))) {
                     return false;
                 }
             }

--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/RuleRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/RuleRequestMatcher.java
@@ -1,0 +1,87 @@
+package com.github.dreamhead.moco.matcher;
+
+import com.github.dreamhead.moco.MocoConfig;
+import com.github.dreamhead.moco.Request;
+import com.github.dreamhead.moco.RequestExtractor;
+import com.github.dreamhead.moco.RequestMatcher;
+import com.github.dreamhead.moco.model.MessageContent;
+import com.github.dreamhead.moco.resource.Resource;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionException;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class RuleRequestMatcher<T> extends AbstractRequestMatcher {
+
+    private final RequestExtractor<T> extractor;
+
+    private final Resource expected;
+
+    private final ExpressionParser parser;
+
+    public RuleRequestMatcher(final Resource expected, final RequestExtractor<T> extractor) {
+
+        this.extractor = extractor;
+
+        this.expected = expected;
+
+        this.parser = new SpelExpressionParser();
+    }
+
+
+    @Override
+    public RequestMatcher doApply(final MocoConfig config) {
+        Resource appliedResource = this.expected.apply(config);
+        if (appliedResource == this.expected) {
+            return this;
+        }
+
+        return new RuleRequestMatcher<>(appliedResource, this.extractor);
+    }
+
+    @Override
+    public boolean match(Request request) {
+        Optional<T> extractContent = extractor.extract(request);
+        String rule = expected.readFor(request).toString();
+        return extractContent.filter(content -> this.matchContent(content
+                , rule, request)).isPresent();
+    }
+
+
+    private boolean matchContent(final T target, final String rule, final Request request) {
+        if (target instanceof String) {
+            return ruleMatch((String) target, rule, request);
+        }
+
+        if (target instanceof String[]) {
+            String[] contents = (String[]) target;
+            return Arrays.stream(contents).filter(Objects::nonNull).anyMatch(content -> ruleMatch(content, rule, request));
+        }
+
+        if (target instanceof MessageContent) {
+            MessageContent actualTarget = (MessageContent) target;
+            return ruleMatch(actualTarget.toString(), rule, request);
+        }
+
+        return false;
+    }
+
+    private boolean ruleMatch(final String content, final String rule, final Request request) {
+
+        try {
+            EvaluationContext context = new StandardEvaluationContext();
+            Expression exp = parser.parseExpression(rule);
+            context.setVariable("value", content);
+            context.setVariable("request", request);
+            return Optional.ofNullable(exp.getValue(context, Boolean.class)).orElse(false);
+        } catch (ExpressionException e) {
+            return false;
+        }
+    }
+}

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoJsonTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoJsonTest.java
@@ -96,7 +96,7 @@ public class MocoJsonTest extends AbstractMocoHttpTest {
         final String ruleJsonText = Jsons.toJson("#value['foo'] == 'bar2'");
 //        final String ruleJsonText = Jsons.toJson(of("foo", "#value == 'bar2'"));
         final String requestJsonText = Jsons.toJson(of("foo", "bar2"));
-        server.request(as(json(ruleJsonText), true)).response("foo");
+        server.request(rule(json(ruleJsonText))).response("foo");
         running(server, () -> assertThat(helper.postContent(root(), requestJsonText), is("foo")));
     }
 
@@ -107,7 +107,7 @@ public class MocoJsonTest extends AbstractMocoHttpTest {
 //        final String ruleJsonText = "{\"name\":\"#value.equalsIgnoreCase('linus')\"}";
         final String requestJsonText = "{\"name\":\"Linus\",\"location\":\"Portland\"}";
         final String responseText = "${req.json.name} is such a cool guy from ${req.json.location}.";
-        server.request(as(json(ruleJsonText), true)).response(template(responseText));
+        server.request(rule(json(ruleJsonText))).response(template(responseText));
         running(server, () -> assertThat(helper.postContent(root(), requestJsonText), is("Linus is such a cool guy from Portland.")));
     }
 

--- a/moco-core/src/test/java/com/github/dreamhead/moco/MocoTest.java
+++ b/moco-core/src/test/java/com/github/dreamhead/moco/MocoTest.java
@@ -20,31 +20,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.dreamhead.moco.HttpProtocolVersion.VERSION_1_0;
-import static com.github.dreamhead.moco.Moco.and;
-import static com.github.dreamhead.moco.Moco.binary;
-import static com.github.dreamhead.moco.Moco.by;
-import static com.github.dreamhead.moco.Moco.conditional;
-import static com.github.dreamhead.moco.Moco.contain;
-import static com.github.dreamhead.moco.Moco.cycle;
-import static com.github.dreamhead.moco.Moco.endsWith;
-import static com.github.dreamhead.moco.Moco.eq;
-import static com.github.dreamhead.moco.Moco.exist;
-import static com.github.dreamhead.moco.Moco.file;
-import static com.github.dreamhead.moco.Moco.header;
-import static com.github.dreamhead.moco.Moco.latency;
-import static com.github.dreamhead.moco.Moco.match;
-import static com.github.dreamhead.moco.Moco.method;
-import static com.github.dreamhead.moco.Moco.not;
-import static com.github.dreamhead.moco.Moco.or;
-import static com.github.dreamhead.moco.Moco.pathResource;
-import static com.github.dreamhead.moco.Moco.query;
-import static com.github.dreamhead.moco.Moco.seq;
-import static com.github.dreamhead.moco.Moco.startsWith;
-import static com.github.dreamhead.moco.Moco.status;
-import static com.github.dreamhead.moco.Moco.text;
-import static com.github.dreamhead.moco.Moco.uri;
-import static com.github.dreamhead.moco.Moco.version;
-import static com.github.dreamhead.moco.Moco.with;
+import static com.github.dreamhead.moco.Moco.*;
 import static com.github.dreamhead.moco.Runner.running;
 import static com.github.dreamhead.moco.helper.RemoteTestUtils.remoteUrl;
 import static com.github.dreamhead.moco.helper.RemoteTestUtils.root;
@@ -400,6 +376,26 @@ public class MocoTest extends AbstractMocoHttpTest {
     }
 
     @Test
+    public void should_rule() throws Exception {
+        server.request(rule(uri("#value.startsWith('/foo')"))).response("bar");
+
+        running(server, () -> {
+            assertThat(helper.get(remoteUrl("/foo/a")), is("bar"));
+            assertThat(helper.get(remoteUrl("/foo/b")), is("bar"));
+        });
+    }
+
+    @Test
+    public void should_rule_for_resource() throws Exception {
+        server.request(rule(header("foo"), "#value.endsWith('bar')")).response("bar");
+
+        running(server, () -> {
+            assertThat(helper.getWithHeader(root(), of("foo", "Abar")), is("bar"));
+            assertThat(helper.getWithHeader(root(), of("foo", "Bbar")), is("bar"));
+        });
+    }
+
+    @Test
     public void should_contain() throws Exception {
         server.request(contain(uri("foo"))).response("bar");
 
@@ -681,21 +677,21 @@ public class MocoTest extends AbstractMocoHttpTest {
 
     @Test
     public void should_return_binary() throws Exception {
-        server.response(binary(new byte[] {1, 2, 3}));
+        server.response(binary(new byte[]{1, 2, 3}));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
     @Test
     public void should_return_binary_with_byte_buffer() throws Exception {
-        server.response(binary(ByteBuffer.wrap(new byte[] {1, 2, 3})));
+        server.response(binary(ByteBuffer.wrap(new byte[]{1, 2, 3})));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
@@ -707,7 +703,7 @@ public class MocoTest extends AbstractMocoHttpTest {
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
@@ -733,7 +729,7 @@ public class MocoTest extends AbstractMocoHttpTest {
 
     @Test
     public void should_return_dynamic_text_with_arguments_function() throws Exception {
-        server.response(text((request) -> ((HttpRequest)request).getUri()));
+        server.response(text((request) -> ((HttpRequest) request).getUri()));
 
         running(server, () -> {
             String response = helper.get(remoteUrl("/uri"));
@@ -743,41 +739,41 @@ public class MocoTest extends AbstractMocoHttpTest {
 
     @Test
     public void should_return_dynamic_binary() throws Exception {
-        server.response(binary((request) -> new byte[] {1, 2, 3}));
+        server.response(binary((request) -> new byte[]{1, 2, 3}));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
     @Test
     public void should_return_dynamic_binary_function() throws Exception {
-        server.response(binary((request) -> new byte[] {1, 2, 3}));
+        server.response(binary((request) -> new byte[]{1, 2, 3}));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
     @Test
     public void should_return_dynamic_binary_function_with_byte_buffer() throws Exception {
-        server.response(binary((request) -> ByteBuffer.wrap(new byte[] {1, 2, 3})));
+        server.response(binary((request) -> ByteBuffer.wrap(new byte[]{1, 2, 3})));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
     @Test
     public void should_return_dynamic_binary_function_with_input_stream() throws Exception {
-        server.response(binary((request) -> new ByteArrayInputStream(new byte[] {1, 2, 3})));
+        server.response(binary((request) -> new ByteArrayInputStream(new byte[]{1, 2, 3})));
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {1, 2, 3}));
+            assertThat(asBytes, is(new byte[]{1, 2, 3}));
         });
     }
 
@@ -787,7 +783,7 @@ public class MocoTest extends AbstractMocoHttpTest {
 
         running(server, () -> {
             byte[] asBytes = helper.getAsBytes(root());
-            assertThat(asBytes, is(new byte[] {'f', 'o', 'o'}));
+            assertThat(asBytes, is(new byte[]{'f', 'o', 'o'}));
         });
     }
 

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/parser/model/DynamicRequestMatcherFactory.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/parser/model/DynamicRequestMatcherFactory.java
@@ -17,10 +17,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
-import static com.github.dreamhead.moco.Moco.by;
-import static com.github.dreamhead.moco.Moco.eq;
-import static com.github.dreamhead.moco.Moco.exist;
-import static com.github.dreamhead.moco.Moco.not;
+import static com.github.dreamhead.moco.Moco.*;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
@@ -54,7 +51,9 @@ public final class DynamicRequestMatcherFactory extends Dynamics implements Requ
         if ("json".equalsIgnoreCase(name)) {
             return by(Moco.json(value));
         }
-
+        if ("jsonRule".equalsIgnoreCase(name)) {
+            return rule(Moco.json(value));
+        }
         if (value instanceof Map) {
             return createCompositeMatcher(name, castToMap(value));
         }

--- a/moco-runner/src/main/java/com/github/dreamhead/moco/parser/model/RequestSetting.java
+++ b/moco-runner/src/main/java/com/github/dreamhead/moco/parser/model/RequestSetting.java
@@ -24,6 +24,8 @@ public final class RequestSetting extends BaseResourceSetting {
     private Map<String, TextContainer> queries;
     private Map<String, TextContainer> cookies;
     private Map<String, TextContainer> forms;
+    @JsonProperty("json_rule")
+    private Object jsonRule;
 
     protected MoreObjects.ToStringHelper toStringHelper() {
         return super.toStringHelper()
@@ -35,7 +37,9 @@ public final class RequestSetting extends BaseResourceSetting {
                 .add("json paths", jsonPaths)
                 .add("queries", queries)
                 .add("cookies", cookies)
-                .add("forms", forms);
+                .add("forms", forms)
+                .add("json_rule", jsonRule);
+
     }
 
     public RequestMatcher getRequestMatcher() {

--- a/moco-runner/src/test/java/com/github/dreamhead/moco/MocoRuleTest.java
+++ b/moco-runner/src/test/java/com/github/dreamhead/moco/MocoRuleTest.java
@@ -1,0 +1,52 @@
+package com.github.dreamhead.moco;
+
+
+import com.google.common.net.HttpHeaders;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.github.dreamhead.moco.helper.RemoteTestUtils.remoteUrl;
+import static com.google.common.collect.ImmutableMultimap.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MocoRuleTest extends AbstractMocoStandaloneTest {
+    @Test
+    public void should_match_uri() throws IOException {
+        runWithConfiguration("rule.json");
+        assertThat(helper.get(remoteUrl("/foo/bar")), is("uri_match"));
+        assertThat(helper.get(remoteUrl("/foo/blah")), is("uri_match"));
+    }
+
+    @Test
+    public void should_match_text() throws IOException {
+        runWithConfiguration("rule.json");
+        assertThat(helper.postContent(remoteUrl("/text-match"), "foobar"), is("text_match"));
+        assertThat(helper.postContent(remoteUrl("/text-match"), "fooblah"), is("text_match"));
+    }
+
+    @Test
+    public void should_match_header() throws IOException {
+        runWithConfiguration("rule.json");
+
+        assertThat(helper.getWithHeader(remoteUrl("/header-match"), of(HttpHeaders.CONTENT_TYPE, "application/json")), is("header_match"));
+        assertThat(helper.getWithHeader(remoteUrl("/header-match"), of(HttpHeaders.CONTENT_TYPE, "application/xml")), is("header_match"));
+    }
+
+    @Test
+    public void should_match_query() throws IOException {
+        runWithConfiguration("rule.json");
+
+        assertThat(helper.get(remoteUrl("/query-match?foo=bar")), is("query_match"));
+        assertThat(helper.get(remoteUrl("/query-match?foo=blah")), is("query_match"));
+    }
+
+    @Test
+    public void should_match_json() throws IOException {
+        runWithConfiguration("rule.json");
+
+        assertThat(helper.postContent(remoteUrl("/json-match"), "{\n\t\"name\":\"Linus\"\n}"), is("json_match"));
+        assertThat(helper.postContent(remoteUrl("/json-match"), "{\n\t\"name\":\"linus\"\n}"), is("json_match"));
+    }
+}

--- a/moco-runner/src/test/resources/rule.json
+++ b/moco-runner/src/test/resources/rule.json
@@ -1,0 +1,60 @@
+[
+  {
+    "request": {
+      "uri": {
+        "rule": "#value.startsWith('/foo')"
+      }
+    },
+    "response": {
+      "text": "uri_match"
+    }
+  },
+  {
+    "request": {
+      "uri": "/text-match",
+      "text": {
+        "rule": "#value.startsWith('foo')"
+      }
+    },
+    "response": {
+      "text": "text_match"
+    }
+  },
+  {
+    "request": {
+      "uri": "/header-match",
+      "headers": {
+        "content-type": {
+          "rule": "#value.startsWith('application')"
+        }
+      }
+    },
+    "response": {
+      "text": "header_match"
+    }
+  },
+  {
+    "request": {
+      "uri": "/query-match",
+      "queries": {
+        "foo": {
+          "rule": "#value.startsWith('b')"
+        }
+      }
+    },
+    "response": {
+      "text": "query_match"
+    }
+  },
+  {
+    "request": {
+      "uri": "/json-match",
+      "json_rule": {
+        "name": "#value.equalsIgnoreCase('Linus')"
+      }
+    },
+    "response": {
+      "text": "json_match"
+    }
+  }
+]


### PR DESCRIPTION
eg:
```java
  @Test
  public void should_match_rule_json() throws Exception {
        final String ruleJsonText = Jsons.toJson("#value['foo'] == 'bar2'");
//        final String ruleJsonText = Jsons.toJson(of("foo", "#value == 'bar2'"));
        final String requestJsonText = Jsons.toJson(of("foo", "bar2"));
        server.request(rule(json(ruleJsonText))).response("foo");
        running(server, () -> assertThat(helper.postContent(root(), requestJsonText), is("foo")));
    }
```
result:
```text
Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)
BUILD SUCCESSFUL in 4s
```
eg:
```java
  @Test
    public void should_match_rule_json_with_resource() throws Exception {

        final String ruleJsonText = "\"#value[name].equalsIgnoreCase('linus')||#value[name]=='Dreamhead'\"";
//        final String ruleJsonText = "{\"name\":\"#value.equalsIgnoreCase('linus')\"}";
        final String requestJsonText = "{\"name\":\"Linus\",\"location\":\"Portland\"}";
        final String responseText = "${req.json.name} is such a cool guy from ${req.json.location}.";
        server.request(rule(json(ruleJsonText))).response(template(responseText));
        running(server, () -> assertThat(helper.postContent(root(), requestJsonText), is("Linus is such a cool guy from Portland.")));
    }
```
result:
```text
Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)
BUILD SUCCESSFUL in 5s
```

