### PR TITLE
fixed wrong array match in json struct request matcher

### DIFF
--- a/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonStructRequestMatcher.java
+++ b/moco-core/src/main/java/com/github/dreamhead/moco/matcher/JsonStructRequestMatcher.java
@@ -38,12 +38,12 @@ public final class JsonStructRequestMatcher extends JsonRequestMatcher {
         }
 
         if (actual.isArray() && expected.isArray()) {
-            if (actual.isEmpty()) {
+            if (actual.isEmpty() || expected.isEmpty()) {
                 return true;
             }
-            JsonNode templateNode = actual.get(0);
-            return Streams.stream(expected)
-                    .allMatch(node -> doMatch(templateNode, node));
+            JsonNode templateNode = expected.get(0);
+            return Streams.stream(actual)
+                    .allMatch(node -> doMatch(node, templateNode));
         }
 
         if (actual.isBinary() && expected.isBinary()) {


### PR DESCRIPTION

test
```java
 @Test(expected = HttpResponseException.class)
    public void should_match_same_structure_json_with_resource() throws Exception {
        final String jsonContent = "{\"foo\":\"bar\",\"foo2\":[\"bar\"]}";
        final String jsonContent2 = "{\"foo\":\"bar\",\"foo2\":[\"bar\",2,3]}";
        server.request(struct(json(jsonContent))).response("foo");
        running(server, () -> assertThat(helper.postContent(root(), jsonContent2), is("foo")));
    }
```

before fixed:
result:
```tex
Results: FAILURE (1 tests, 0 successes, 1 failures, 0 skipped)
BUILD FAILED in 4s
```

after fixed
```tex
Results: SUCCESS (1 tests, 1 successes, 0 failures, 0 skipped)
BUILD SUCCESSFUL in 4s
4 actionable tasks: 2 executed, 2 up-to-date
```

