### PR TITLE
Add CI build using Github Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ["8", "11", "17"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '${{ matrix.java-version }}'
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+
+      - name: Build
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ subprojects {
         testImplementation(
                 "org.junit.jupiter:junit-jupiter-api:$junitVersion",
                 "org.junit.jupiter:junit-jupiter-engine:$junitVersion",
+                "org.junit.jupiter:junit-jupiter-params:$junitVersion",
                 "org.hamcrest:hamcrest-core:$hamcrestVersion",
                 "org.hamcrest:hamcrest-library:$hamcrestVersion",
                 "org.mockito:mockito-core:$mockitoVersion",


### PR DESCRIPTION
I'd like to add CI build using GitHub Action, so that we can fix the build status badge in [README.md](README.md).

Adding the build itself is straight forward. However, the build seems stuck on one particular test:
```java
    @Test
    public void should_proxy_with_request_method() throws Exception {
        server.get(by(uri("/target"))).response("get_proxy");
        server.post(and(by(uri("/target")), by("proxy"))).response("post_proxy");
        server.request(and(by(uri("/target")), by(method("put")), by("proxy"))).response("put_proxy");
        server.request(and(by(uri("/target")), by(method("delete")))).response("delete_proxy");
        server.request(and(by(uri("/target")), by(method("head")))).response(status(200));
        server.request(and(by(uri("/target")), by(method("options")))).response("options_proxy");
        server.request(and(by(uri("/target")), by(method("trace")))).response("trace_proxy");

        server.request(by(uri("/proxy"))).response(proxy(remoteUrl("/target")));

        running(server, () -> {
            assertThat(helper.get(remoteUrl("/proxy")), is("get_proxy"));
            assertThat(helper.postContent(remoteUrl("/proxy"), "proxy"), is("post_proxy"));

            Request putRequest = Request.put(remoteUrl("/proxy")).bodyString("proxy", ContentType.DEFAULT_TEXT);
            assertThat(helper.executeAsString(putRequest), is("put_proxy"));

            Request deleteRequest = Request.delete(remoteUrl("/proxy"));
            assertThat(helper.executeAsString(deleteRequest), is("delete_proxy"));

            Request headRequest = Request.head(remoteUrl("/proxy"));
            int code = helper.execute(headRequest).getCode();
            assertThat(code, is(200));

            Request optionsRequest = Request.options(remoteUrl("/proxy"));
            assertThat(helper.executeAsString(optionsRequest), is("options_proxy"));

            Request traceRequest = Request.trace(remoteUrl("/proxy"));
            assertThat(helper.executeAsString(traceRequest), is("trace_proxy"));
        });
    }
```

While the test passes locally with no issue, it hangs on one of the `PUT` / `DELETE` / `HEAD` / `OPTIONS` / `TRACE`. The test passes on CI, if only one of the above was executed. Any combination of two (or more) causes the build to hang.

I wasn't able to get to the bottom of cause, but I suspect it has to do with resource releasing.

I refactored the test to use `@ParameterizedTest` to both help passing the build and remove some code duplication in the test. And effectively added `PATCH` under test as well. However it does introduce a new test dependency: `org.junit.jupiter:junit-jupiter-params`.

<img width="491" alt="Screenshot 2023-09-10 at 11 44 15 PM" src="https://github.com/dreamhead/moco/assets/163554/aff4b527-8ca7-476e-9f16-aa0c7897d3f7">

