### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </a>
 
 # [Moco](https://github.com/dreamhead/moco) 
-[![Build Status](https://travis-ci.org/dreamhead/moco.png?branch=master)](https://travis-ci.org/dreamhead/moco)
+[![Build](https://github.com/dreamhead/moco/actions/workflows/build.yaml/badge.svg)](https://github.com/dreamhead/moco/actions/workflows/build.yaml)
 [![HitCount](http://hits.dwyl.com/dreamhead/moco.svg?style=flat-square)](http://hits.dwyl.com/dreamhead/moco)
 
 Moco is an easy setup stub framework.


### PR DESCRIPTION
Show GitHub Actions status badge now that we have it.

<img width="491" alt="Screenshot 2023-09-19 at 9 26 19 PM" src="https://github.com/dreamhead/moco/assets/163554/5acc4830-cec5-483f-85eb-1af2fa7bf72f">
