### PR TITLE
Use maven version badge to auto update latest release info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 Moco is an easy setup stub framework.
 
 ## Latest Release
-* __1.5.0__
-
-More details in [Release Notes](moco-doc/ReleaseNotes.md)
+* [![Maven Central](https://img.shields.io/maven-central/v/com.github.dreamhead/moco-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.github.dreamhead/moco-core)
+* [Release Notes](moco-doc/ReleaseNotes.md)
 
 ## User Voice
 * [Let me know](https://jinshuju.net/f/Agawf9) if you are using Moco.


### PR DESCRIPTION
### Change:
* Use Maven version badge to auto display latest release
* Minor format change to move release notes into bulletins

### Note:
Currently the badge is pointing to `moco-core`

### Visual:
<img width="434" alt="Screenshot 2023-09-20 at 11 13 27 AM" src="https://github.com/dreamhead/moco/assets/163554/7105fe46-ba57-4c35-a44a-338fb288ffc9">
